### PR TITLE
Assign invoice numbers server-side

### DIFF
--- a/components/FinancialsView.tsx
+++ b/components/FinancialsView.tsx
@@ -119,19 +119,22 @@ const InvoiceModal: React.FC<{ invoiceToEdit?: Invoice | null, isReadOnly?: bool
                 subtotal, taxAmount, retentionAmount, total, amountPaid, balance,
                 payments: invoiceToEdit?.payments || [],
                 status: invoiceToEdit?.status || InvoiceStatus.DRAFT,
-                invoiceNumber: invoiceToEdit?.invoiceNumber || `INV-${Math.floor(Math.random() * 9000) + 1000}`,
             };
             if(invoiceToEdit) {
-                 await api.updateInvoice(invoiceToEdit.id, invoiceData, user.id);
-                 addToast("Invoice updated.", "success");
+                 const updated = await api.updateInvoice(invoiceToEdit.id, { ...invoiceData, invoiceNumber: invoiceToEdit.invoiceNumber }, user.id);
+                 addToast(`Invoice ${updated.invoiceNumber} updated.`, "success");
             } else {
-                 await api.createInvoice(invoiceData, user.id);
-                 addToast("Invoice created as draft.", "success");
+                 const created = await api.createInvoice(invoiceData, user.id);
+                 if (!created.invoiceNumber) {
+                    throw new Error("Invoice number was not returned by the server.");
+                 }
+                 addToast(`Invoice ${created.invoiceNumber} created as draft.`, "success");
             }
             onSuccess();
             onClose();
         } catch(e) {
-            addToast("Failed to save invoice.", "error");
+            const message = e instanceof Error && e.message ? e.message : "Failed to save invoice.";
+            addToast(message, "error");
         } finally {
             setIsSaving(false);
         }

--- a/services/mockData.ts
+++ b/services/mockData.ts
@@ -37,7 +37,7 @@ export const initialData = {
       { id: 'e-1', description: 'Client Lunch', amount: 150, category: 'Other', projectId: '101', userId: '2', date: '2024-01-15', status: ExpenseStatus.APPROVED }
     ] as Partial<Expense>[],
     invoices: [
-        { id: 'inv-1', invoiceNumber: 'INV-001', projectId: '101', clientId: 'c-1', issueDate: '2024-01-20', dueDate: '2024-02-20', status: InvoiceStatus.PAID, lineItems: [{id: 'li-1', description: 'Phase 1', quantity: 1, rate: 100000, amount: 100000}], subtotal: 100000, taxRate: 0.2, taxAmount: 20000, retentionRate: 0.05, retentionAmount: 5000, total: 115000, amountPaid: 115000, balance: 0 }
+        { id: 'inv-1', companyId: '1', invoiceNumber: 'INV-001', projectId: '101', clientId: 'c-1', issueDate: '2024-01-20', dueDate: '2024-02-20', status: InvoiceStatus.PAID, lineItems: [{id: 'li-1', description: 'Phase 1', quantity: 1, rate: 100000, amount: 100000}], subtotal: 100000, taxRate: 0.2, taxAmount: 20000, retentionRate: 0.05, retentionAmount: 5000, total: 115000, amountPaid: 115000, balance: 0 }
     ] as Partial<Invoice>[],
     siteUpdates: [
         { id: 'su-1', projectId: '101', userId: '3', message: 'Concrete pour for the ground floor is complete.', timestamp: new Date(Date.now() - 2 * 3600 * 1000).toISOString(), images: ['https://picsum.photos/seed/concrete/400/200'] },


### PR DESCRIPTION
## Summary
- delegate invoice number generation to the mock API and validate duplicates
- update the invoice modal to rely on the API-provided number and surface errors
- seed invoice data with company ownership for numbering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8bc57cf0483279c84d0c7d72b81e3