### PR TITLE
Enhance workspace UI and enforce view permissions

### DIFF
--- a/components/AllTasksView.tsx
+++ b/components/AllTasksView.tsx
@@ -6,6 +6,7 @@ import { Card } from './ui/Card';
 import { Button } from './ui/Button';
 import { KanbanBoard } from './KanbanBoard';
 import { TaskModal } from './TaskModal';
+import { ViewHeader } from './layout/ViewHeader';
 
 interface AllTasksViewProps {
   user: User;
@@ -23,8 +24,21 @@ export const AllTasksView: React.FC<AllTasksViewProps> = ({ user, addToast, isOn
     const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
     const [taskToEdit, setTaskToEdit] = useState<Todo | null>(null);
     const [bulkAction, setBulkAction] = useState({ type: '', value: '' });
-    
+
     const canManage = hasPermission(user, Permission.MANAGE_ALL_TASKS);
+
+    const taskSummary = useMemo(() => {
+        const total = todos.length;
+        const inProgress = todos.filter(t => t.status === TodoStatus.IN_PROGRESS).length;
+        const completed = todos.filter(t => t.status === TodoStatus.DONE).length;
+        const overdue = todos.filter(t => {
+            if (!t.dueDate || t.status === TodoStatus.DONE) return false;
+            const due = new Date(t.dueDate);
+            return !Number.isNaN(due.getTime()) && due < new Date();
+        }).length;
+        const completionRate = total > 0 ? Math.round((completed / total) * 100) : 0;
+        return { total, inProgress, completed, overdue, completionRate };
+    }, [todos]);
 
     const fetchData = useCallback(async () => {
         setLoading(true);
@@ -129,36 +143,68 @@ export const AllTasksView: React.FC<AllTasksViewProps> = ({ user, addToast, isOn
     return (
         <div className="space-y-6">
             {isTaskModalOpen && <TaskModal user={user} projects={projects} users={personnel} onClose={() => setIsTaskModalOpen(false)} onSuccess={handleTaskModalSuccess} addToast={addToast} taskToEdit={taskToEdit} allProjectTasks={todos}/>}
-            <div className="flex justify-between items-center">
-                <h2 className="text-3xl font-bold text-slate-800">All Tasks</h2>
-                {canManage && <Button onClick={() => handleOpenTaskModal(null)}>Add Task</Button>}
-            </div>
+            <ViewHeader
+                view="all-tasks"
+                actions={canManage ? <Button onClick={() => handleOpenTaskModal(null)}>Add Task</Button> : undefined}
+                meta={[
+                    {
+                        label: 'Total tasks',
+                        value: `${taskSummary.total}`,
+                        helper: `${taskSummary.completionRate}% complete`,
+                    },
+                    {
+                        label: 'In progress',
+                        value: `${taskSummary.inProgress}`,
+                        helper: 'Actively being worked',
+                        indicator: taskSummary.inProgress > 0 ? 'positive' : 'neutral',
+                    },
+                    {
+                        label: 'Overdue',
+                        value: `${taskSummary.overdue}`,
+                        helper: taskSummary.overdue > 0 ? 'Needs attention' : 'On track',
+                        indicator: taskSummary.overdue > 0 ? 'negative' : 'positive',
+                    },
+                ]}
+            />
 
-            <Card>
-                <div className="flex flex-wrap gap-4 items-center p-4 border-b">
-                    <div className="flex items-center gap-2">
-                         <input type="checkbox" checked={isAllSelected} onChange={handleSelectAll} className="h-4 w-4 rounded" />
-                         <label>Select All</label>
-                    </div>
-                    <select value={selectedProjectId} onChange={e => setSelectedProjectId(e.target.value)} className="p-2 border rounded bg-white dark:bg-slate-800">
-                        <option value="all">All Projects</option>
+            <Card className="p-0">
+                <div className="flex flex-wrap items-center gap-4 px-4 py-4">
+                    <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <input type="checkbox" checked={isAllSelected} onChange={handleSelectAll} className="h-4 w-4 rounded border-border text-primary focus:ring-primary" />
+                        Select all
+                    </label>
+                    <select
+                        value={selectedProjectId}
+                        onChange={e => setSelectedProjectId(e.target.value)}
+                        className="rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none"
+                    >
+                        <option value="all">All projects</option>
                         {projects.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
                     </select>
                 </div>
                 {selectedTaskIds.size > 0 && (
-                    <div className="p-4 bg-sky-50 dark:bg-sky-900/50 flex flex-wrap gap-4 items-center">
-                        <span className="font-semibold">{selectedTaskIds.size} tasks selected</span>
-                        <select onChange={e => setBulkAction({ type: 'status', value: e.target.value })} className="p-2 border rounded bg-white dark:bg-slate-800">
-                            <option value="">Change Status...</option>
-                            {Object.values(TodoStatus).map(s => <option key={s} value={s}>{s}</option>)}
+                    <div className="flex flex-wrap items-center gap-4 border-t border-border bg-primary/5 px-4 py-4 text-sm">
+                        <span className="font-semibold text-foreground">{selectedTaskIds.size} task(s) selected</span>
+                        <select
+                            onChange={e => setBulkAction({ type: 'status', value: e.target.value })}
+                            className="rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none"
+                        >
+                            <option value="">Change status...</option>
+                            {Object.values(TodoStatus).map(s => <option key={s} value={s}>{s.replace(/_/g, ' ')}</option>)}
                         </select>
-                         <select onChange={e => setBulkAction({ type: 'assignee', value: e.target.value })} className="p-2 border rounded bg-white dark:bg-slate-800">
-                            <option value="">Change Assignee...</option>
+                        <select
+                            onChange={e => setBulkAction({ type: 'assignee', value: e.target.value })}
+                            className="rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none"
+                        >
+                            <option value="">Change assignee...</option>
                             <option value="unassigned">Unassigned</option>
                             {personnel.map(p => <option key={p.id} value={p.id}>{`${p.firstName} ${p.lastName}`}</option>)}
                         </select>
-                         <select onChange={e => setBulkAction({ type: 'priority', value: e.target.value })} className="p-2 border rounded bg-white dark:bg-slate-800">
-                            <option value="">Change Priority...</option>
+                        <select
+                            onChange={e => setBulkAction({ type: 'priority', value: e.target.value })}
+                            className="rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none"
+                        >
+                            <option value="">Change priority...</option>
                             {Object.values(TodoPriority).map(p => <option key={p} value={p}>{p}</option>)}
                         </select>
                         <Button onClick={handleApplyBulkAction}>Apply</Button>

--- a/components/ClientsView.tsx
+++ b/components/ClientsView.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 // FIX: Corrected import paths to be relative.
 import { User, Client } from '../types';
 import { api } from '../services/mockApi';
 import { Card } from './ui/Card';
 import { Button } from './ui/Button';
+import { ViewHeader } from './layout/ViewHeader';
+import { Tag } from './ui/Tag';
 
 interface ClientsViewProps {
   user: User;
@@ -31,45 +33,81 @@ export const ClientsView: React.FC<ClientsViewProps> = ({ user, addToast }) => {
         fetchData();
     }, [fetchData]);
 
+    const summary = useMemo(() => {
+        const total = clients.length;
+        const active = clients.filter(client => client.isActive).length;
+        const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+        const newThisMonth = clients.filter(client => {
+            const created = new Date(client.createdAt);
+            return !Number.isNaN(created.getTime()) && Date.now() - created.getTime() <= thirtyDays;
+        }).length;
+        return { total, active, newThisMonth };
+    }, [clients]);
+
     if (loading) {
         return <Card><p>Loading clients...</p></Card>;
     }
 
     return (
-        <div>
-            <div className="flex justify-between items-center mb-6">
-                <h2 className="text-3xl font-bold text-slate-800">Clients</h2>
-                <Button variant="primary">
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                    </svg>
-                    Add Client
-                </Button>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="space-y-6">
+            <ViewHeader
+                view="clients"
+                actions={
+                    <Button>
+                        <svg xmlns="http://www.w3.org/2000/svg" className="mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                        </svg>
+                        Add client
+                    </Button>
+                }
+                meta={[
+                    {
+                        label: 'Total accounts',
+                        value: `${summary.total}`,
+                        helper: 'Companies you collaborate with',
+                    },
+                    {
+                        label: 'Active',
+                        value: `${summary.active}`,
+                        helper: `${summary.active} currently engaged`,
+                        indicator: summary.active > 0 ? 'positive' : 'neutral',
+                    },
+                    {
+                        label: 'New this month',
+                        value: `${summary.newThisMonth}`,
+                        helper: summary.newThisMonth > 0 ? 'Recent wins' : 'No new clients yet',
+                        indicator: summary.newThisMonth > 0 ? 'positive' : 'neutral',
+                    },
+                ]}
+            />
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
                 {clients.map(client => (
-                    <Card key={client.id} className="animate-card-enter">
-                        <h3 className="text-xl font-semibold text-slate-800 truncate">{client.name}</h3>
-                        <p className="text-sm text-slate-500 mb-4">Member since {new Date(client.createdAt).toLocaleDateString()}</p>
-                        <div className="space-y-2 text-sm border-t pt-4">
-                            <p className="flex items-center gap-2 text-slate-600">
-                                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>
-                                {/* FIX: Corrected property access */}
+                    <Card key={client.id} className="flex h-full flex-col gap-4 animate-card-enter">
+                        <div className="flex items-start justify-between gap-3">
+                            <div>
+                                <h3 className="truncate text-xl font-semibold text-foreground">{client.name}</h3>
+                                <p className="text-sm text-muted-foreground">Partner since {new Date(client.createdAt).toLocaleDateString()}</p>
+                            </div>
+                            <Tag label={client.isActive ? 'Active' : 'Dormant'} color={client.isActive ? 'green' : 'gray'} />
+                        </div>
+                        <div className="space-y-3 rounded-lg border border-border bg-muted/40 p-4 text-sm">
+                            <p className="flex items-center gap-2 text-muted-foreground">
+                                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-muted-foreground/80" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>
                                 {client.contactEmail}
                             </p>
-                            <p className="flex items-center gap-2 text-slate-600">
-                                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" /></svg>
-                                {/* FIX: Corrected property access */}
+                            <p className="flex items-center gap-2 text-muted-foreground">
+                                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-muted-foreground/80" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" /></svg>
                                 {client.contactPhone}
                             </p>
+                            <p className="text-muted-foreground">Payment terms: {client.paymentTerms}</p>
                         </div>
                     </Card>
                 ))}
             </div>
-             {clients.length === 0 && (
-                <Card className="text-center py-12">
-                    <h3 className="text-lg font-medium">No clients found.</h3>
-                    <p className="text-slate-500 mt-1">Get started by adding your first client.</p>
+            {clients.length === 0 && (
+                <Card className="py-12 text-center">
+                    <h3 className="text-lg font-medium text-foreground">No clients found.</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">Get started by adding your first client.</p>
                 </Card>
             )}
         </div>

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -8,6 +8,7 @@ import { hasPermission } from '../services/auth';
 import { Avatar } from './ui/Avatar';
 import { EquipmentStatusBadge } from './ui/StatusBadge';
 import { Tag } from './ui/Tag';
+import { ViewHeader } from './layout/ViewHeader';
 // FIX: Removed `startOfWeek` from import and added a local implementation to resolve the module export error.
 import { format, eachDayOfInterval, isWithinInterval } from 'date-fns';
 
@@ -145,8 +146,29 @@ export const Dashboard: React.FC<DashboardProps> = ({ user, addToast, setActiveV
 
     return (
         <div className="space-y-6">
-            <h1 className="text-3xl font-bold text-foreground">Welcome back, {user.firstName}!</h1>
-            
+            <ViewHeader
+                title={`Welcome back, ${user.firstName}!`}
+                description="Here's how your teams and projects are performing right now."
+                meta={[
+                    {
+                        label: 'Active projects',
+                        value: kpiData.activeProjectsCount.toString(),
+                        indicator: kpiData.activeProjectsCount > 0 ? 'positive' : 'neutral',
+                    },
+                    {
+                        label: 'Team members',
+                        value: kpiData.teamSize.toString(),
+                        helper: 'Across your organisation',
+                    },
+                    {
+                        label: 'Budget utilisation',
+                        value: `${kpiData.budgetUtilization}%`,
+                        helper: 'Across active projects',
+                        indicator: Number(kpiData.budgetUtilization) > 90 ? 'warning' : 'positive',
+                    },
+                ]}
+            />
+
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 <KpiCard title="Active Projects" value={kpiData.activeProjectsCount.toString()} icon={<svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" /></svg>} />
                 <KpiCard title="Team Size" value={kpiData.teamSize.toString()} icon={<svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656-.126-1.283-.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" /></svg>} />

--- a/components/InvoicesView.tsx
+++ b/components/InvoicesView.tsx
@@ -5,6 +5,7 @@ import { Button } from './ui/Button';
 import { Card } from './ui/Card';
 import { InvoiceStatusBadge } from './ui/StatusBadge';
 import { Tag } from './ui/Tag';
+import { ViewHeader } from './layout/ViewHeader';
 import { Client, Invoice, InvoiceStatus, Project, User } from '../types';
 import { getDerivedStatus, getInvoiceFinancials } from '../utils/finance';
 
@@ -341,6 +342,7 @@ export const InvoicesView: React.FC<InvoicesViewProps> = ({ user, addToast }) =>
   const selectedInvoiceStatus = selectedInvoice ? getDerivedStatus(selectedInvoice) : null;
   const selectedInvoiceFinancials = selectedInvoice ? getInvoiceFinancials(selectedInvoice) : null;
   const selectedAging = selectedInvoice ? getAgingInfo(selectedInvoice) : null;
+  const collectionIndicator = summary.collectionRate >= 90 ? 'positive' : summary.collectionRate >= 75 ? 'warning' : 'negative';
 
   return (
     <div className="relative space-y-6">
@@ -554,22 +556,39 @@ export const InvoicesView: React.FC<InvoicesViewProps> = ({ user, addToast }) =>
         </div>
       )}
 
-      <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold">Invoices</h1>
-          <p className="text-sm text-muted-foreground">
-            Monitor billing health, follow up on overdue accounts, and record payments as they arrive.
-          </p>
-        </div>
-        <Button
-          variant="secondary"
-          onClick={() =>
-            addToast('Invoice creation is available from the Financials workspace.', 'success')
-          }
-        >
-          New invoice
-        </Button>
-      </div>
+      <ViewHeader
+        view="invoices"
+        actions={
+          <Button
+            variant="secondary"
+            onClick={() =>
+              addToast('Invoice creation is available from the Financials workspace.', 'success')
+            }
+          >
+            New invoice
+          </Button>
+        }
+        meta={[
+          {
+            label: 'Outstanding balance',
+            value: formatCurrency(summary.outstanding),
+            helper: summary.outstanding > 0 ? 'Across open invoices' : 'All invoices settled',
+            indicator: summary.outstanding > 0 ? 'warning' : 'positive',
+          },
+          {
+            label: 'Overdue exposure',
+            value: formatCurrency(summary.overdue),
+            helper: summary.overdue > 0 ? 'Requires follow up' : 'No overdue balances',
+            indicator: summary.overdue > 0 ? 'negative' : 'positive',
+          },
+          {
+            label: 'Collection rate',
+            value: `${summary.collectionRate}%`,
+            helper: 'Paid in the last 30 days',
+            indicator: collectionIndicator,
+          },
+        ]}
+      />
 
       {loading ? (
         <Card>Loading invoices...</Card>

--- a/components/ProjectsView.tsx
+++ b/components/ProjectsView.tsx
@@ -1,12 +1,14 @@
 // full contents of components/ProjectsView.tsx
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { User, Project, Permission } from '../types';
+import { User, Project, Permission, ProjectStatus } from '../types';
 import { api } from '../services/mockApi';
 import { hasPermission } from '../services/auth';
 import { Card } from './ui/Card';
 import { Button } from './ui/Button';
 import { ProjectModal } from './CreateProjectModal';
+import { ViewHeader } from './layout/ViewHeader';
+import { Tag } from './ui/Tag';
 
 interface ProjectsViewProps {
   user: User;
@@ -14,35 +16,79 @@ interface ProjectsViewProps {
   onSelectProject: (project: Project) => void;
 }
 
+const statusAccent: Record<ProjectStatus, { bg: string; text: string }> = {
+    PLANNING: { bg: 'bg-amber-500/10', text: 'text-amber-700 dark:text-amber-300' },
+    ACTIVE: { bg: 'bg-emerald-500/10', text: 'text-emerald-700 dark:text-emerald-300' },
+    ON_HOLD: { bg: 'bg-amber-500/10', text: 'text-amber-700 dark:text-amber-300' },
+    COMPLETED: { bg: 'bg-primary/10', text: 'text-primary dark:text-primary-200' },
+    CANCELLED: { bg: 'bg-slate-500/10', text: 'text-slate-500 dark:text-slate-300' },
+};
+
+const formatCurrency = (value: number): string =>
+    new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', notation: 'compact', compactDisplay: 'short' }).format(value || 0);
+
 const ProjectCard: React.FC<{ project: Project; onSelect: () => void; }> = ({ project, onSelect }) => {
-    const budgetUtilization = (project.actualCost / project.budget) * 100;
+    const budgetUtilization = project.budget > 0 ? (project.actualCost / project.budget) * 100 : 0;
+    const statusStyles = statusAccent[project.status] ?? statusAccent.PLANNING;
+    const overBudget = budgetUtilization > 100;
+
     return (
-        <Card onClick={onSelect} className="cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all animate-card-enter">
-            <img src={project.imageUrl} alt={project.name} className="w-full h-40 object-cover rounded-lg mb-4" />
-            <h3 className="font-bold text-lg truncate">{project.name}</h3>
-            <p className="text-sm text-slate-500">{project.location.address}</p>
-            <div className="flex justify-between items-center mt-4 text-sm">
-                <span className={`px-2 py-0.5 rounded-full text-xs font-semibold ${
-// FIX: Changed status strings to uppercase to match type definitions.
-                    project.status === 'ACTIVE' ? 'bg-green-100 text-green-800' :
-                    project.status === 'COMPLETED' ? 'bg-sky-100 text-sky-800' : 'bg-yellow-100 text-yellow-800'
-                }`}>{project.status}</span>
-                <span>Budget: £{(project.budget/1000).toFixed(0)}k</span>
+        <Card onClick={onSelect} className="group cursor-pointer space-y-4 transition-all hover:-translate-y-1 hover:shadow-lg animate-card-enter">
+            <div className="relative h-40 overflow-hidden rounded-lg bg-muted">
+                {project.imageUrl ? (
+                    <img src={project.imageUrl} alt={project.name} className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" />
+                ) : (
+                    <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">No cover image</div>
+                )}
+                <div className="absolute left-3 top-3 flex items-center gap-2 text-xs font-semibold">
+                    <Tag label={project.projectType} color="blue" />
+                    <Tag label={project.workClassification} color="gray" />
+                </div>
             </div>
-            <div className="w-full bg-gray-200 rounded-full h-1.5 mt-2">
-                <div 
-                    className={`${budgetUtilization > 100 ? 'bg-red-500' : 'bg-green-600'}`}
-                    style={{ width: `${Math.min(100, budgetUtilization)}%`, height: '100%', borderRadius: 'inherit' }}
-                ></div>
+            <div className="space-y-2">
+                <div className="flex items-start justify-between gap-3">
+                    <div>
+                        <h3 className="text-lg font-semibold text-foreground line-clamp-2">{project.name}</h3>
+                        <p className="text-xs text-muted-foreground">{project.location.address}</p>
+                    </div>
+                    <span className={`rounded-full px-3 py-1 text-xs font-semibold ${statusStyles.bg} ${statusStyles.text}`}>
+                        {project.status.replace(/_/g, ' ')}
+                    </span>
+                </div>
+                <div className="flex items-center justify-between text-sm text-muted-foreground">
+                    <span>Budget {formatCurrency(project.budget)}</span>
+                    <span className={overBudget ? 'font-semibold text-rose-500 dark:text-rose-300' : 'text-emerald-600 dark:text-emerald-300'}>
+                        {overBudget ? `+${Math.round(budgetUtilization - 100)}%` : `${Math.round(budgetUtilization)}% used`}
+                    </span>
+                </div>
+                <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                        className={`${overBudget ? 'bg-rose-500' : 'bg-emerald-500'} h-full rounded-full transition-all`}
+                        style={{ width: `${Math.min(100, Math.max(0, budgetUtilization))}%` }}
+                    />
+                </div>
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>Start {new Date(project.startDate).toLocaleDateString()}</span>
+                    <span>Due {new Date(project.endDate).toLocaleDateString()}</span>
+                </div>
             </div>
         </Card>
     );
 };
 
+const PROJECT_FILTERS: Array<{ label: string; value: 'ALL' | ProjectStatus }> = [
+    { label: 'All', value: 'ALL' },
+    { label: 'Active', value: 'ACTIVE' },
+    { label: 'Planning', value: 'PLANNING' },
+    { label: 'On Hold', value: 'ON_HOLD' },
+    { label: 'Completed', value: 'COMPLETED' },
+    { label: 'Cancelled', value: 'CANCELLED' },
+];
+
 export const ProjectsView: React.FC<ProjectsViewProps> = ({ user, addToast, onSelectProject }) => {
     const [projects, setProjects] = useState<Project[]>([]);
     const [loading, setLoading] = useState(true);
-    const [filter, setFilter] = useState('All');
+    const [filter, setFilter] = useState<'ALL' | ProjectStatus>('ALL');
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
     const canCreate = hasPermission(user, Permission.CREATE_PROJECT);
@@ -71,9 +117,31 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({ user, addToast, onSe
     }, [fetchData]);
     
     const filteredProjects = useMemo(() => {
-        if (filter === 'All') return projects;
+        if (filter === 'ALL') return projects;
         return projects.filter(p => p.status === filter);
     }, [projects, filter]);
+
+    const portfolioSummary = useMemo(() => {
+        if (projects.length === 0) {
+            return {
+                total: 0,
+                active: 0,
+                atRisk: 0,
+                pipelineValue: 0,
+            };
+        }
+
+        const active = projects.filter(p => p.status === 'ACTIVE').length;
+        const atRisk = projects.filter(p => p.actualCost > p.budget).length;
+        const pipelineValue = projects.reduce((acc, project) => acc + project.budget, 0);
+
+        return {
+            total: projects.length,
+            active,
+            atRisk,
+            pipelineValue,
+        };
+    }, [projects]);
 
     const handleSuccess = (newProject: Project) => {
         setProjects(prev => [...prev, newProject]);
@@ -82,24 +150,55 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({ user, addToast, onSe
 
     if (loading) return <Card><p>Loading projects...</p></Card>;
 
+    const activeShare = portfolioSummary.total > 0 ? Math.round((portfolioSummary.active / portfolioSummary.total) * 100) : 0;
+
     return (
         <div className="space-y-6">
             {isCreateModalOpen && (
-                <ProjectModal 
-                    user={user} 
+                <ProjectModal
+                    user={user}
                     onClose={() => setIsCreateModalOpen(false)}
                     onSuccess={handleSuccess}
                     addToast={addToast}
                 />
             )}
-            <div className="flex justify-between items-center">
-                <h2 className="text-3xl font-bold text-slate-800">Projects</h2>
-                {canCreate && <Button onClick={() => setIsCreateModalOpen(true)}>Create Project</Button>}
-            </div>
-            
-            <div className="flex gap-2">
-                {['All', 'Active', 'Planning', 'Completed', 'On Hold'].map(f => (
-                    <button key={f} onClick={() => setFilter(f)} className={`px-3 py-1 text-sm rounded-full ${filter === f ? 'bg-sky-600 text-white' : 'bg-white hover:bg-slate-100'}`}>{f}</button>
+            <ViewHeader
+                view="projects"
+                actions={canCreate ? <Button onClick={() => setIsCreateModalOpen(true)}>Create Project</Button> : undefined}
+                meta={[
+                    {
+                        label: 'Portfolio value',
+                        value: formatCurrency(portfolioSummary.pipelineValue),
+                        helper: 'Budgeted across all projects',
+                    },
+                    {
+                        label: 'Active projects',
+                        value: `${portfolioSummary.active}`,
+                        helper: portfolioSummary.total > 0 ? `${activeShare}% of portfolio` : 'No projects yet',
+                        indicator: portfolioSummary.active > 0 ? 'positive' : 'neutral',
+                    },
+                    {
+                        label: 'Over budget',
+                        value: `${portfolioSummary.atRisk}`,
+                        helper: portfolioSummary.atRisk > 0 ? 'Requires commercial review' : 'No overruns detected',
+                        indicator: portfolioSummary.atRisk > 0 ? 'negative' : 'positive',
+                    },
+                ]}
+            />
+
+            <div className="flex flex-wrap gap-2">
+                {PROJECT_FILTERS.map(filterOption => (
+                    <button
+                        key={filterOption.value}
+                        onClick={() => setFilter(filterOption.value)}
+                        className={`rounded-full px-3 py-1.5 text-sm transition-colors ${
+                            filter === filterOption.value
+                                ? 'bg-primary text-primary-foreground shadow-sm'
+                                : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                        }`}
+                    >
+                        {filterOption.label}
+                    </button>
                 ))}
             </div>
 

--- a/components/layout/ViewAccessBoundary.tsx
+++ b/components/layout/ViewAccessBoundary.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { User, View, Permission, Role } from '../../types';
+import { Button } from '../ui/Button';
+import { Card } from '../ui/Card';
+import { Tag } from '../ui/Tag';
+import {
+  evaluateViewAccess,
+  getDefaultViewForUser,
+  getViewDisplayName,
+  viewMetadata,
+  ViewAccessEvaluation,
+} from '../../utils/viewAccess';
+
+interface ViewAccessBoundaryProps {
+  user: User;
+  view: View;
+  evaluation?: ViewAccessEvaluation;
+  fallbackView?: View;
+  onNavigate?: (view: View) => void;
+  children: React.ReactNode;
+}
+
+const humanise = (value: string): string =>
+  value
+    .split('_')
+    .map((segment) => segment.charAt(0) + segment.slice(1).toLowerCase())
+    .join(' ');
+
+const PermissionList: React.FC<{ permissions: Permission[] }> = ({ permissions }) => {
+  const uniquePermissions = Array.from(new Set(permissions));
+
+  if (uniquePermissions.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Required permissions</p>
+      <div className="flex flex-wrap gap-2">
+        {uniquePermissions.map((permission) => (
+          <Tag key={permission} label={humanise(permission)} color="red" statusIndicator="red" />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const AllowedRoleList: React.FC<{ roles?: Role[] }> = ({ roles }) => {
+  if (!roles?.length) return null;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Available for</p>
+      <div className="flex flex-wrap gap-2">
+        {roles.map((role) => (
+          <Tag key={role} label={humanise(role)} color="blue" statusIndicator="blue" />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const ViewAccessBoundary: React.FC<ViewAccessBoundaryProps> = ({
+  user,
+  view,
+  evaluation,
+  fallbackView,
+  onNavigate,
+  children,
+}) => {
+  const access = evaluation ?? evaluateViewAccess(user, view);
+
+  if (access.allowed) {
+    return <>{children}</>;
+  }
+
+  const resolvedFallback = fallbackView ?? access.fallbackView ?? getDefaultViewForUser(user);
+  const fallbackLabel = getViewDisplayName(resolvedFallback);
+  const viewLabel = getViewDisplayName(view);
+  const description = viewMetadata[view]?.description;
+
+  const handleNavigate = (target: View) => {
+    if (onNavigate) {
+      onNavigate(target);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex h-full max-w-3xl flex-col justify-center px-6 py-12">
+      <Card className="border-dashed border-destructive/40 bg-destructive/5 backdrop-blur">
+        <div className="flex flex-col gap-6">
+          <div className="flex items-start gap-4">
+            <span className="flex h-12 w-12 items-center justify-center rounded-full bg-destructive/15 text-destructive">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </span>
+            <div className="space-y-2">
+              <h2 className="text-2xl font-semibold text-foreground">You don’t have access to {viewLabel}</h2>
+              <p className="text-sm text-muted-foreground">
+                {access.reason ||
+                  `This workspace area is restricted for your current role. ${
+                    description ? `It covers: ${description}` : ''
+                  }`}
+              </p>
+            </div>
+          </div>
+
+          <PermissionList permissions={access.missingPermissions} />
+          <AllowedRoleList roles={access.allowedRoles} />
+
+          {onNavigate ? (
+            <div className="flex flex-wrap gap-3">
+              <Button onClick={() => handleNavigate(resolvedFallback)}>Go to {fallbackLabel}</Button>
+              {resolvedFallback !== 'dashboard' && (
+                <Button variant="ghost" onClick={() => handleNavigate(getDefaultViewForUser(user))}>
+                  Back to {getViewDisplayName(getDefaultViewForUser(user))}
+                </Button>
+              )}
+            </div>
+          ) : null}
+        </div>
+      </Card>
+    </div>
+  );
+};
+

--- a/components/layout/ViewHeader.tsx
+++ b/components/layout/ViewHeader.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { View } from '../../types';
+import { viewMetadata } from '../../utils/viewAccess';
+
+export type ViewHeaderIndicator = 'neutral' | 'positive' | 'warning' | 'negative';
+
+export interface ViewHeaderMetaItem {
+  label: string;
+  value: string;
+  helper?: string;
+  indicator?: ViewHeaderIndicator;
+}
+
+interface ViewHeaderProps {
+  title?: string;
+  description?: string;
+  icon?: React.ReactNode;
+  actions?: React.ReactNode;
+  meta?: ViewHeaderMetaItem[];
+  breadcrumbs?: Array<{ label: string; onClick?: () => void; view?: View }>;
+  view?: View;
+  className?: string;
+}
+
+const indicatorClasses: Record<ViewHeaderIndicator, string> = {
+  neutral: 'border-border bg-muted/30 text-muted-foreground',
+  positive: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
+  warning: 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-300',
+  negative: 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300',
+};
+
+export const ViewHeader: React.FC<ViewHeaderProps> = ({
+  title,
+  description,
+  icon,
+  actions,
+  meta,
+  breadcrumbs,
+  view,
+  className = '',
+}) => {
+  const resolvedTitle = title ?? (view ? viewMetadata[view]?.title : undefined);
+  const resolvedDescription = description ?? (view ? viewMetadata[view]?.description : undefined);
+
+  return (
+    <section
+      className={`relative overflow-hidden rounded-[--radius] border border-border bg-card/80 p-6 shadow-sm backdrop-blur ${className}`}
+    >
+      <span className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary/40 via-primary/20 to-transparent dark:from-primary/60" />
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
+          {icon ? (
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              {icon}
+            </div>
+          ) : null}
+          <div>
+            {breadcrumbs?.length ? (
+              <div className="mb-1 flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+                {breadcrumbs.map((crumb, index) => (
+                  <React.Fragment key={crumb.label}>
+                    {index > 0 && <span className="opacity-60">/</span>}
+                    {crumb.onClick ? (
+                      <button
+                        type="button"
+                        onClick={crumb.onClick}
+                        className="font-semibold text-muted-foreground transition-colors hover:text-primary"
+                      >
+                        {crumb.label}
+                      </button>
+                    ) : (
+                      <span>{crumb.label}</span>
+                    )}
+                  </React.Fragment>
+                ))}
+              </div>
+            ) : null}
+            {resolvedTitle ? <h1 className="text-2xl font-semibold text-foreground md:text-3xl">{resolvedTitle}</h1> : null}
+            {resolvedDescription ? (
+              <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{resolvedDescription}</p>
+            ) : null}
+          </div>
+        </div>
+        {actions ? <div className="flex flex-wrap gap-3 text-sm">{actions}</div> : null}
+      </div>
+
+      {meta?.length ? (
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {meta.map((item) => (
+            <div
+              key={`${item.label}-${item.value}`}
+              className={`rounded-lg border px-4 py-3 text-sm shadow-sm transition-colors ${
+                indicatorClasses[item.indicator ?? 'neutral']
+              }`}
+            >
+              <p className="text-xs font-semibold uppercase tracking-wide opacity-75">{item.label}</p>
+              <p className="mt-2 text-xl font-semibold text-foreground">{item.value}</p>
+              {item.helper ? <p className="mt-1 text-xs text-muted-foreground">{item.helper}</p> : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+};
+

--- a/utils/viewAccess.ts
+++ b/utils/viewAccess.ts
@@ -1,0 +1,266 @@
+import { Permission, Role, User, View } from '../types';
+import { hasPermission } from '../services/auth';
+
+export interface ViewMetadata {
+  title: string;
+  description: string;
+}
+
+export interface ViewAccessRule {
+  anyPermissions?: Permission[];
+  allPermissions?: Permission[];
+  allowedRoles?: Role[];
+  description?: string;
+  fallbackView?: View;
+}
+
+export interface ViewAccessEvaluation {
+  view: View;
+  allowed: boolean;
+  missingPermissions: Permission[];
+  allowedRoles?: Role[];
+  reason?: string;
+  fallbackView?: View;
+}
+
+const projectVisibilityRule: ViewAccessRule = {
+  anyPermissions: [Permission.VIEW_ALL_PROJECTS, Permission.VIEW_ASSIGNED_PROJECTS],
+  description: 'Project visibility is required to review portfolio information.',
+};
+
+const documentVisibilityRule: ViewAccessRule = {
+  anyPermissions: [Permission.VIEW_DOCUMENTS, Permission.UPLOAD_DOCUMENTS],
+  description: 'Document access is needed to browse project files and upload content.',
+};
+
+const safetyRule: ViewAccessRule = {
+  anyPermissions: [Permission.VIEW_SAFETY_REPORTS, Permission.SUBMIT_SAFETY_REPORT],
+  description: 'Safety permissions ensure only authorised crew can view and log incidents.',
+};
+
+const financialRule: ViewAccessRule = {
+  anyPermissions: [Permission.VIEW_FINANCES, Permission.MANAGE_FINANCES],
+  description: 'Financial permissions allow visibility into invoices, payments and cost tracking.',
+};
+
+export const viewMetadata: Record<View, ViewMetadata> = {
+  dashboard: {
+    title: 'Operations Overview',
+    description: 'High-level summary of current projects, teams and resources.',
+  },
+  'my-day': {
+    title: 'My Day',
+    description: 'Personalised task list and checkpoints for field teams.',
+  },
+  'foreman-dashboard': {
+    title: 'Field Operations',
+    description: 'Site level insights and crew coordination tools.',
+  },
+  'principal-dashboard': {
+    title: 'Platform Administration',
+    description: 'Portfolio-wide analytics and partner performance.',
+  },
+  projects: {
+    title: 'Projects',
+    description: 'Monitor schedules, risk and budget performance across every job.',
+  },
+  'project-detail': {
+    title: 'Project Detail',
+    description: 'Deep dive into milestones, tasks and resourcing for a single project.',
+  },
+  'all-tasks': {
+    title: 'Work Coordination',
+    description: 'Aggregate kanban to review task status and unblock teams quickly.',
+  },
+  map: {
+    title: 'Project Map',
+    description: 'Geospatial view of active sites and crews.',
+  },
+  time: {
+    title: 'Time Clock',
+    description: 'Log hours worked and review current shifts.',
+  },
+  timesheets: {
+    title: 'Timesheets',
+    description: 'Approve or reconcile submitted timesheets and labour entries.',
+  },
+  documents: {
+    title: 'Documents',
+    description: 'Organise drawings, RFIs and project artefacts.',
+  },
+  safety: {
+    title: 'Safety',
+    description: 'Capture incidents, toolbox talks and compliance checks.',
+  },
+  financials: {
+    title: 'Financials',
+    description: 'Budget consumption, forecasts and commercial analytics.',
+  },
+  users: {
+    title: 'Teams',
+    description: 'Manage workforce availability and role assignments.',
+  },
+  equipment: {
+    title: 'Equipment',
+    description: 'Asset readiness, maintenance and utilisation.',
+  },
+  templates: {
+    title: 'Templates',
+    description: 'Reusable project schedules, workflows and document sets.',
+  },
+  tools: {
+    title: 'Toolbox',
+    description: 'Access to AI copilots and productivity extensions.',
+  },
+  'audit-log': {
+    title: 'Audit Log',
+    description: 'System activity trail for compliance and investigations.',
+  },
+  settings: {
+    title: 'Workspace Settings',
+    description: 'Company preferences, billing and platform configuration.',
+  },
+  chat: {
+    title: 'Messages',
+    description: 'Direct and group messaging across crews and partners.',
+  },
+  clients: {
+    title: 'Clients',
+    description: 'CRM overview of customer accounts and health.',
+  },
+  invoices: {
+    title: 'Invoices',
+    description: 'Billing pipeline, receivables and payment status.',
+  },
+};
+
+export const viewAccessRules: Partial<Record<View, ViewAccessRule>> = {
+  projects: projectVisibilityRule,
+  map: projectVisibilityRule,
+  'project-detail': projectVisibilityRule,
+  'all-tasks': {
+    anyPermissions: [Permission.VIEW_ALL_TASKS, Permission.MANAGE_ALL_TASKS],
+    description: 'Task visibility is required to review and manage work packages.',
+  },
+  time: {
+    anyPermissions: [Permission.SUBMIT_TIMESHEET, Permission.MANAGE_TIMESHEETS],
+    description: 'Only authorised crew can log or manage time entries.',
+  },
+  timesheets: {
+    anyPermissions: [Permission.VIEW_ALL_TIMESHEETS, Permission.MANAGE_TIMESHEETS],
+    description: 'Timesheet approval rights are needed to review labour history.',
+  },
+  documents: documentVisibilityRule,
+  safety: safetyRule,
+  financials: financialRule,
+  invoices: financialRule,
+  users: {
+    anyPermissions: [Permission.VIEW_TEAM, Permission.MANAGE_TEAM],
+    description: 'Team administration requires workforce visibility permissions.',
+  },
+  equipment: {
+    anyPermissions: [Permission.MANAGE_EQUIPMENT],
+    description: 'Equipment control ensures assets are managed by the operations team.',
+  },
+  templates: {
+    anyPermissions: [Permission.MANAGE_PROJECT_TEMPLATES],
+    description: 'Template library is reserved for portfolio leads.',
+  },
+  tools: {
+    anyPermissions: [Permission.ACCESS_ALL_TOOLS],
+    description: 'Toolbox modules are restricted to teams with platform extensions.',
+  },
+  'audit-log': {
+    anyPermissions: [Permission.VIEW_AUDIT_LOG],
+    description: 'Audit information is available to compliance and admin roles.',
+  },
+  chat: {
+    anyPermissions: [Permission.SEND_DIRECT_MESSAGE],
+    description: 'Messaging requires communication privileges.',
+  },
+  clients: {
+    anyPermissions: [Permission.VIEW_ALL_PROJECTS, Permission.MANAGE_FINANCES],
+    description: 'Client records are tied to portfolio or commercial permissions.',
+  },
+  'foreman-dashboard': {
+    allowedRoles: [Role.FOREMAN, Role.PROJECT_MANAGER, Role.ADMIN, Role.OWNER],
+    description: 'Field dashboards are tailored for operations leadership.',
+    fallbackView: 'dashboard',
+  },
+  'principal-dashboard': {
+    allowedRoles: [Role.PRINCIPAL_ADMIN],
+    description: 'Only platform administrators can access the principal dashboard.',
+    fallbackView: 'dashboard',
+  },
+};
+
+export const getDefaultViewForUser = (user: User): View => {
+  switch (user.role) {
+    case Role.OPERATIVE:
+      return 'my-day';
+    case Role.FOREMAN:
+      return 'foreman-dashboard';
+    case Role.PRINCIPAL_ADMIN:
+      return 'principal-dashboard';
+    default:
+      return 'dashboard';
+  }
+};
+
+export const getViewDisplayName = (view: View): string => viewMetadata[view]?.title ?? view;
+
+export const evaluateViewAccess = (user: User, view: View): ViewAccessEvaluation => {
+  const rule = viewAccessRules[view];
+
+  if (!rule) {
+    return {
+      view,
+      allowed: true,
+      missingPermissions: [],
+    };
+  }
+
+  if (rule.allowedRoles && !rule.allowedRoles.includes(user.role)) {
+    return {
+      view,
+      allowed: false,
+      missingPermissions: [],
+      allowedRoles: rule.allowedRoles,
+      reason: rule.description,
+      fallbackView: rule.fallbackView,
+    };
+  }
+
+  const missingPermissions: Permission[] = [];
+
+  if (rule.anyPermissions) {
+    const hasAny = rule.anyPermissions.some((permission) => hasPermission(user, permission));
+    if (!hasAny) {
+      missingPermissions.push(...rule.anyPermissions);
+    }
+  }
+
+  if (rule.allPermissions) {
+    const missing = rule.allPermissions.filter((permission) => !hasPermission(user, permission));
+    missingPermissions.push(...missing);
+  }
+
+  if (missingPermissions.length > 0) {
+    return {
+      view,
+      allowed: false,
+      missingPermissions,
+      reason: rule.description,
+      fallbackView: rule.fallbackView,
+    };
+  }
+
+  return {
+    view,
+    allowed: true,
+    missingPermissions: [],
+  };
+};
+
+export const canAccessView = (user: User, view: View): boolean => evaluateViewAccess(user, view).allowed;
+


### PR DESCRIPTION
## Summary
- add a reusable view access matrix with metadata and evaluation helpers plus a boundary component to guard navigation and surface missing permissions
- introduce a shared view header component and apply it to key workspaces to deliver consistent, role-aware portfolio summaries and filters
- refresh project, task, client, invoice, and dashboard screens with richer cards, analytics, and theme-aware styling

## Testing
- `npm run build`
- `npm run test` *(fails: vitest executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d0c2787c83278807e97ce04113c6