### PR TITLE
Add AI cash-flow forecasting workflow

### DIFF
--- a/components/FinancialsView.tsx
+++ b/components/FinancialsView.tsx
@@ -1,20 +1,24 @@
- codex/add-abort-feature-to-fetchdata
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { User, FinancialKPIs, MonthlyFinancials, CostBreakdown, Invoice, Quote, Client, Project, Permission, Expense, ExpenseCategory, ExpenseStatus, InvoiceStatus, QuoteStatus, LineItem, Payment, InvoiceLineItem } from '../types';
-
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
-
-codex/refactor-finance-functions-and-components
-import { User, FinancialKPIs, MonthlyFinancials, CostBreakdown, Invoice, Quote, Client, Project, Permission, Expense, InvoiceStatus, InvoiceLineItem } from '../types';
+import {
+  User,
+  FinancialKPIs,
+  MonthlyFinancials,
+  CostBreakdown,
+  Invoice,
+  Quote,
+  Client,
+  Project,
+  Permission,
+  Expense,
+  ExpenseStatus,
+  InvoiceStatus,
+  InvoiceLineItem,
+  InvoiceLineItemDraft,
+  FinancialForecast,
+} from '../types';
 import { getDerivedStatus, getInvoiceFinancials } from '../utils/finance';
-import { User, FinancialKPIs, MonthlyFinancials, CostBreakdown, Invoice, Quote, Client, Project, Permission, Expense, ExpenseCategory, ExpenseStatus, InvoiceStatus, QuoteStatus, InvoiceLineItem, InvoiceLineItemDraft } from '../types';
-
-
-import { User, FinancialKPIs, MonthlyFinancials, CostBreakdown, Invoice, Quote, Client, Project, Permission, Expense, InvoiceStatus, InvoiceLineItem } from '../types';
-import { getDerivedStatus, getInvoiceFinancials } from '../utils/finance';
-
- 
 import { api } from '../services/mockApi';
+import { generateFinancialForecast } from '../services/ai';
 import { Card } from './ui/Card';
 import { Button } from './ui/Button';
 import { InvoiceStatusBadge, QuoteStatusBadge } from './ui/StatusBadge';
@@ -24,648 +28,1293 @@ import { ExpenseModal } from './ExpenseModal';
 
 type FinancialsTab = 'dashboard' | 'invoices' | 'expenses' | 'clients';
 
-const formatCurrency = (amount: number, currency: string = 'GBP') => {
-    return new Intl.NumberFormat('en-GB', { style: 'currency', currency, minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(amount);
+const formatCurrency = (amount: number, currency: string = 'GBP') =>
+  new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+
+const formatSignedPercentage = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return '0%';
+  }
+  const rounded = Number(value.toFixed(1));
+  const prefix = rounded > 0 ? '+' : '';
+  return `${prefix}${rounded}%`;
 };
 
 const createLineItemDraft = (): InvoiceLineItemDraft => ({
-    id: `new-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-    description: '',
-    quantity: 1,
-    unitPrice: 0,
+  id: `new-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  description: '',
+  quantity: 1,
+  unitPrice: 0,
 });
 
 const mapInvoiceLineItemToDraft = (item: InvoiceLineItem): InvoiceLineItemDraft => {
-    const safeQuantity = Number.isFinite(item.quantity) ? Math.max(item.quantity, 0) : 0;
-    const safeRate = Number.isFinite(item.rate) ? Math.max(item.rate, 0) : 0;
-    const safeUnitPrice = Number.isFinite(item.unitPrice) ? Math.max(item.unitPrice, 0) : safeRate;
+  const safeQuantity = Number.isFinite(item.quantity) ? Math.max(item.quantity, 0) : 0;
+  const safeRate = Number.isFinite(item.rate) ? Math.max(item.rate, 0) : 0;
+  const safeUnitPrice = Number.isFinite(item.unitPrice) ? Math.max(item.unitPrice, 0) : safeRate;
 
-    return {
-        id: item.id,
-        description: item.description,
-        quantity: safeQuantity,
-        unitPrice: safeUnitPrice > 0 ? safeUnitPrice : safeRate,
-    };
+  return {
+    id: item.id,
+    description: item.description,
+    quantity: safeQuantity,
+    unitPrice: safeUnitPrice > 0 ? safeUnitPrice : safeRate,
+  };
 };
 
 const parseNumberInputValue = (value: string): number => {
-    if (value.trim() === '') {
-        return 0;
-    }
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : 0;
+  if (value.trim() === '') {
+    return 0;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
 };
 
 type EditableInvoiceLineItemField = Exclude<keyof InvoiceLineItemDraft, 'id'>;
 
-// --- Modals ---
+const ClientModal: React.FC<{
+  clientToEdit?: Client | null;
+  onClose: () => void;
+  onSuccess: () => void;
+  user: User;
+  addToast: (message: string, type: 'success' | 'error') => void;
+}> = ({ clientToEdit, onClose, onSuccess, user, addToast }) => {
+  const [name, setName] = useState(clientToEdit?.name || '');
+  const [email, setEmail] = useState(clientToEdit?.contactEmail || '');
+  const [phone, setPhone] = useState(clientToEdit?.contactPhone || '');
+  const [address, setAddress] = useState(clientToEdit?.billingAddress || '');
+  const [terms, setTerms] = useState(clientToEdit?.paymentTerms || 'Net 30');
+  const [isSaving, setIsSaving] = useState(false);
 
-const ClientModal: React.FC<{ clientToEdit?: Client | null, onClose: () => void, onSuccess: () => void, user: User, addToast: (m:string,t:'success'|'error')=>void }> = ({ clientToEdit, onClose, onSuccess, user, addToast }) => {
-    const [name, setName] = useState(clientToEdit?.name || '');
-    const [email, setEmail] = useState(clientToEdit?.contactEmail || '');
-    const [phone, setPhone] = useState(clientToEdit?.contactPhone || '');
-    const [address, setAddress] = useState(clientToEdit?.billingAddress || '');
-    const [terms, setTerms] = useState(clientToEdit?.paymentTerms || 'Net 30');
-    const [isSaving, setIsSaving] = useState(false);
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setIsSaving(true);
-        try {
-            const clientData = { name, contactEmail: email, contactPhone: phone, billingAddress: address, paymentTerms: terms };
-            if (clientToEdit) {
-                await api.updateClient(clientToEdit.id, clientData, user.id);
-                addToast("Client updated.", "success");
-            } else {
-                await api.createClient(clientData, user.id);
-                addToast("Client added.", "success");
-            }
-            onSuccess();
-            onClose();
-        } catch(e) {
-            addToast("Failed to save client.", "error");
-        } finally {
-            setIsSaving(false);
-        }
-    };
-    
-    return (
-        <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4" onClick={onClose}>
-            <Card className="w-full max-w-lg" onClick={e=>e.stopPropagation()}>
-                <h3 className="text-lg font-bold mb-4">{clientToEdit ? 'Edit Client' : 'Add New Client'}</h3>
-                <form onSubmit={handleSubmit} className="space-y-4">
-                    <input type="text" value={name} onChange={e=>setName(e.target.value)} placeholder="Client Name" className="w-full p-2 border rounded" required/>
-                    <input type="email" value={email} onChange={e=>setEmail(e.target.value)} placeholder="Contact Email" className="w-full p-2 border rounded" required/>
-                    <input type="tel" value={phone} onChange={e=>setPhone(e.target.value)} placeholder="Contact Phone" className="w-full p-2 border rounded" required/>
-                    <textarea value={address} onChange={e=>setAddress(e.target.value)} placeholder="Billing Address" className="w-full p-2 border rounded" rows={3} required/>
-                    <input type="text" value={terms} onChange={e=>setTerms(e.target.value)} placeholder="Payment Terms (e.g., Net 30)" className="w-full p-2 border rounded" required/>
-                    <div className="flex justify-end gap-2"><Button variant="secondary" onClick={onClose}>Cancel</Button><Button type="submit" isLoading={isSaving}>Save Client</Button></div>
-                </form>
-            </Card>
-        </div>
-    );
-};
-
-const InvoiceModal: React.FC<{ invoiceToEdit?: Invoice | null, isReadOnly?: boolean, onClose: () => void, onSuccess: () => void, user: User, clients: Client[], projects: Project[], addToast: (m:string,t:'success'|'error')=>void }> = ({ invoiceToEdit, isReadOnly = false, onClose, onSuccess, user, clients, projects, addToast }) => {
-    const [clientId, setClientId] = useState<string>(invoiceToEdit?.clientId.toString() || '');
-    const [projectId, setProjectId] = useState<string>(invoiceToEdit?.projectId.toString() || '');
-    const [issuedAt, setIssuedAt] = useState(new Date(invoiceToEdit?.issuedAt || new Date()).toISOString().split('T')[0]);
-    const [dueAt, setDueAt] = useState(new Date(invoiceToEdit?.dueAt || Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]);
-    const [lineItems, setLineItems] = useState<InvoiceLineItemDraft[]>(() =>
-        invoiceToEdit?.lineItems?.length
-            ? invoiceToEdit.lineItems.map(mapInvoiceLineItemToDraft)
-            : [createLineItemDraft()],
-    );
-    const [taxRate, setTaxRate] = useState<number | ''>(invoiceToEdit ? invoiceToEdit.taxRate * 100 : 20);
-    const [retentionRate, setRetentionRate] = useState<number | ''>(invoiceToEdit ? invoiceToEdit.retentionRate * 100 : 5);
-    const [notes, setNotes] = useState(invoiceToEdit?.notes || '');
-    const [isSaving, setIsSaving] = useState(false);
-
-    useEffect(() => {
-        setLineItems(
-            invoiceToEdit?.lineItems?.length
-                ? invoiceToEdit.lineItems.map(mapInvoiceLineItemToDraft)
-                : [createLineItemDraft()],
-        );
-    }, [invoiceToEdit?.id]);
-
-    const handleLineItemChange = <Field extends EditableInvoiceLineItemField>(
-        index: number,
-        field: Field,
-        value: InvoiceLineItemDraft[Field],
-    ) => {
-        setLineItems((prevItems) =>
-            prevItems.map((item, itemIndex) => (itemIndex === index ? { ...item, [field]: value } : item)),
-        );
-    };
-
-    const addLineItem = () => setLineItems((prevItems) => [...prevItems, createLineItemDraft()]);
-    const removeLineItem = (index: number) =>
-        setLineItems((prevItems) => prevItems.filter((_, itemIndex) => itemIndex !== index));
-
-    const { subtotal, taxAmount, retentionAmount, total } = useMemo(() => {
-        const subtotalCalc = lineItems.reduce((acc, item) => acc + item.quantity * item.unitPrice, 0);
-        const taxPercentage = typeof taxRate === 'number' ? taxRate : 0;
-        const retentionPercentage = typeof retentionRate === 'number' ? retentionRate : 0;
-        const taxAmountCalc = subtotalCalc * (taxPercentage / 100);
-        const retentionAmountCalc = subtotalCalc * (retentionPercentage / 100);
-        const totalCalc = subtotalCalc + taxAmountCalc - retentionAmountCalc;
-        return { subtotal: subtotalCalc, taxAmount: taxAmountCalc, retentionAmount: retentionAmountCalc, total: totalCalc };
-    }, [lineItems, taxRate, retentionRate]);
-    
-    const amountPaid = invoiceToEdit?.amountPaid || 0;
-    const balance = total - amountPaid;
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setIsSaving(true);
-        try {
-            const finalLineItems = lineItems.reduce<InvoiceLineItem[]>((acc, item) => {
-                const description = item.description.trim();
-                const quantity = Math.max(item.quantity, 0);
-                const unitPrice = Math.max(item.unitPrice, 0);
-
-                if (!description || quantity <= 0 || unitPrice <= 0) {
-                    return acc;
-                }
-
-                acc.push({
-                    id: item.id.startsWith('new-') ? String(Date.now() + Math.random()) : item.id,
-                    description,
-                    quantity,
-                    unitPrice,
-                    rate: unitPrice,
-                    amount: quantity * unitPrice,
-                });
-
-                return acc;
-            }, []);
-            
-            const invoiceData = {
-                clientId: clientId,
-                projectId: projectId,
-                issuedAt: new Date(issuedAt).toISOString(),
-                dueAt: new Date(dueAt).toISOString(),
-                lineItems: finalLineItems,
-                taxRate: Number(taxRate) / 100,
-                retentionRate: Number(retentionRate) / 100,
-                notes,
-                subtotal, taxAmount, retentionAmount, total, amountPaid, balance,
-                payments: invoiceToEdit?.payments || [],
-                status: invoiceToEdit?.status || InvoiceStatus.DRAFT,
-            };
-            if(invoiceToEdit) {
-                 const updated = await api.updateInvoice(invoiceToEdit.id, { ...invoiceData, invoiceNumber: invoiceToEdit.invoiceNumber }, user.id);
-                 addToast(`Invoice ${updated.invoiceNumber} updated.`, "success");
-            } else {
-                 const created = await api.createInvoice(invoiceData, user.id);
-                 if (!created.invoiceNumber) {
-                    throw new Error("Invoice number was not returned by the server.");
-                 }
-                 addToast(`Invoice ${created.invoiceNumber} created as draft.`, "success");
-            }
-            onSuccess();
-            onClose();
-        } catch(e) {
-            const message = e instanceof Error && e.message ? e.message : "Failed to save invoice.";
-            addToast(message, "error");
-        } finally {
-            setIsSaving(false);
-        }
-    };
-
-    return (
-        <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4" onClick={onClose}>
-            <Card className="w-full max-w-4xl max-h-[90vh] flex flex-col" onClick={e=>e.stopPropagation()}>
-                <h3 className="text-lg font-bold mb-4">{invoiceToEdit ? `${isReadOnly ? 'View' : 'Edit'} Invoice ${invoiceToEdit.invoiceNumber}` : 'Create Invoice'}</h3>
-                <form onSubmit={handleSubmit} className="space-y-4 overflow-y-auto pr-2 flex-grow">
-                    <div className="grid grid-cols-2 gap-4">
-                        <select value={clientId} onChange={e=>setClientId(e.target.value)} className="w-full p-2 border rounded bg-white dark:bg-slate-800" required disabled={isReadOnly}><option value="">Select Client</option>{clients.map(c=><option key={c.id} value={c.id}>{c.name}</option>)}</select>
-                        <select value={projectId} onChange={e=>setProjectId(e.target.value)} className="w-full p-2 border rounded bg-white dark:bg-slate-800" required disabled={isReadOnly}><option value="">Select Project</option>{projects.map(p=><option key={p.id} value={p.id}>{p.name}</option>)}</select>
-                        <div><label className="text-xs">Issued Date</label><input type="date" value={issuedAt} onChange={e=>setIssuedAt(e.target.value)} className="w-full p-2 border rounded" disabled={isReadOnly}/></div>
-                        <div><label className="text-xs">Due Date</label><input type="date" value={dueAt} onChange={e=>setDueAt(e.target.value)} className="w-full p-2 border rounded" disabled={isReadOnly}/></div>
-                    </div>
-                    <div className="border-t pt-2">
-                        <h4 className="font-semibold">Line Items</h4>
-                        <div className="grid grid-cols-[1fr,90px,130px,130px,40px] gap-2 items-center mt-1 text-xs text-muted-foreground">
-                            <span>Description</span>
-                            <span className="text-right">Quantity</span>
-                            <span className="text-right">Unit Price</span>
-                            <span className="text-right">Amount</span>
-                        </div>
-                        {lineItems.map((item, i) => (
-                            <div key={item.id} className="grid grid-cols-[1fr,90px,130px,130px,40px] gap-2 items-center mt-2">
-                                <input type="text" value={item.description} onChange={e=>handleLineItemChange(i, 'description', e.target.value)} placeholder="Item or service description" className="p-1 border rounded" disabled={isReadOnly}/>
-                                <input type="number" value={item.quantity} onChange={e=>handleLineItemChange(i, 'quantity', parseNumberInputValue(e.target.value))} placeholder="1" className="p-1 border rounded text-right" disabled={isReadOnly}/>
-                                <input type="number" value={item.unitPrice} onChange={e=>handleLineItemChange(i, 'unitPrice', parseNumberInputValue(e.target.value))} placeholder="0.00" className="p-1 border rounded text-right" disabled={isReadOnly}/>
-                                <span className="p-1 text-right font-medium">{formatCurrency(item.quantity * item.unitPrice)}</span>
-                                {!isReadOnly && <Button type="button" variant="danger" size="sm" onClick={() => removeLineItem(i)}>&times;</Button>}
-                            </div>
-                        ))}
-                        {!isReadOnly && <Button type="button" variant="secondary" size="sm" className="mt-2" onClick={addLineItem}>+ Add Item</Button>}
-                    </div>
-                    <div className="border-t pt-4 grid grid-cols-2 gap-8">
-                        <div>
-                             <h4 className="font-semibold mb-2">Notes</h4>
-                            <textarea value={notes} onChange={e=>setNotes(e.target.value)} placeholder="Payment details, terms and conditions..." rows={6} className="p-2 border rounded w-full" disabled={isReadOnly}/>
-                        </div>
-                        <div className="space-y-2">
-                             <h4 className="font-semibold mb-2">Totals</h4>
-                            <div className="flex justify-between items-center"><span className="text-sm">Subtotal:</span><span className="font-medium">{formatCurrency(subtotal)}</span></div>
-                            <div className="flex justify-between items-center"><label htmlFor="taxRate" className="text-sm">Tax (%):</label><input id="taxRate" type="number" value={taxRate} onChange={e=>setTaxRate(e.target.value === '' ? '' : Number(e.target.value))} className="w-24 p-1 border rounded text-right" disabled={isReadOnly}/></div>
-                             <div className="flex justify-between items-center"><span className="text-sm text-muted-foreground">Tax Amount:</span><span>{formatCurrency(taxAmount)}</span></div>
-                             <div className="flex justify-between items-center"><label htmlFor="retentionRate" className="text-sm">Retention (%):</label><input id="retentionRate" type="number" value={retentionRate} onChange={e=>setRetentionRate(e.target.value === '' ? '' : Number(e.target.value))} className="w-24 p-1 border rounded text-right" disabled={isReadOnly}/></div>
-                            <div className="flex justify-between items-center"><span className="text-sm text-red-600">Retention Held:</span><span className="text-red-600 font-medium">-{formatCurrency(retentionAmount)}</span></div>
-                            <div className="flex justify-between items-center font-bold text-lg pt-2 border-t"><span >Total Due:</span><span>{formatCurrency(total)}</span></div>
-                            {invoiceToEdit && (
-                                <>
-                                 <div className="flex justify-between items-center text-sm"><span >Amount Paid:</span><span>-{formatCurrency(amountPaid)}</span></div>
-                                 <div className="flex justify-between items-center font-bold text-lg text-green-600"><span >Balance:</span><span>{formatCurrency(balance)}</span></div>
-                                </>
-                            )}
-                        </div>
-                    </div>
-                </form>
-                <div className="flex justify-end gap-2 pt-4 border-t mt-4 flex-shrink-0">
-                    <Button variant="secondary" onClick={onClose}>{isReadOnly ? 'Close' : 'Cancel'}</Button>
-                    {!isReadOnly && <Button type="submit" isLoading={isSaving} onClick={handleSubmit}>Save Invoice</Button>}
-                </div>
-            </Card>
-        </div>
-    );
-};
-
-const PaymentModal: React.FC<{ invoice: Invoice, balance: number, onClose: () => void, onSuccess: () => void, user: User, addToast: (m:string,t:'success'|'error')=>void }> = ({ invoice, balance, onClose, onSuccess, user, addToast }) => {
-    const [amount, setAmount] = useState<number|''>(balance > 0 ? balance : '');
-    const [method, setMethod] = useState<'CREDIT_CARD'|'BANK_TRANSFER'|'CASH'>('BANK_TRANSFER');
-    const [isSaving, setIsSaving] = useState(false);
-    
-    const handleSubmit = async () => {
-        const numericAmount = Number(amount);
-        if (amount === '' || numericAmount <= 0) { addToast("Invalid amount", 'error'); return; }
-        if (numericAmount > balance) { addToast("Amount exceeds the outstanding balance", 'error'); return; }
-        setIsSaving(true);
-        try {
-            await api.recordPaymentForInvoice(invoice.id, { amount: numericAmount, method }, user.id);
-            addToast("Payment recorded.", "success");
-            onSuccess();
-            onClose();
-        } catch(e) {
-            addToast("Failed to record payment.", "error");
-        } finally {
-            setIsSaving(false);
-        }
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSaving(true);
+    try {
+      const clientData = {
+        name,
+        contactEmail: email,
+        contactPhone: phone,
+        billingAddress: address,
+        paymentTerms: terms,
+      };
+      if (clientToEdit) {
+        await api.updateClient(clientToEdit.id, clientData, user.id);
+        addToast('Client updated.', 'success');
+      } else {
+        await api.createClient(clientData, user.id);
+        addToast('Client added.', 'success');
+      }
+      onSuccess();
+      onClose();
+    } catch (error) {
+      addToast('Failed to save client.', 'error');
+    } finally {
+      setIsSaving(false);
     }
-    
-    return (
-        <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4" onClick={onClose}>
-            <Card className="w-full max-w-md" onClick={e=>e.stopPropagation()}>
-                <h3 className="text-lg font-bold">Record Payment for {invoice.invoiceNumber}</h3>
-                <p className="text-sm text-muted-foreground mb-4">Current balance: {formatCurrency(balance)}</p>
-                <input type="number" value={amount} onChange={e=>setAmount(e.target.value==='' ? '' : Number(e.target.value))} placeholder={`Enter amount (up to ${balance.toFixed(2)})`} className="w-full p-2 border rounded mt-4" max={balance} />
-                <select value={method} onChange={e=>setMethod(e.target.value as any)} className="w-full p-2 border rounded mt-2 bg-white"><option value="BANK_TRANSFER">Bank Transfer</option><option value="CREDIT_CARD">Card</option><option value="CASH">Cash</option></select>
-                <div className="flex justify-end gap-2 mt-4"><Button variant="secondary" onClick={onClose}>Cancel</Button><Button onClick={handleSubmit} isLoading={isSaving}>Record Payment</Button></div>
-            </Card>
-        </div>
-    );
-}
+  };
 
-const BarChart: React.FC<{ data: { label: string, value: number }[], barColor: string }> = ({ data, barColor }) => {
-    const maxValue = Math.max(...data.map(d => d.value), 0);
-    return (
-        <div className="w-full h-64 flex items-end justify-around p-4 border rounded-lg bg-slate-50 dark:bg-slate-800">
-            {data.map((item, index) => (
-                <div key={index} className="flex flex-col items-center justify-end h-full w-full">
-                    <div className={`w-3/4 rounded-t-md ${barColor}`} style={{ height: `${maxValue > 0 ? (item.value / maxValue) * 100 : 0}%` }} title={formatCurrency(item.value)}></div>
-                    <span className="text-xs mt-2 text-slate-600">{item.label}</span>
-                </div>
-            ))}
-        </div>
-    );
+  return (
+    <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4" onClick={onClose}>
+      <Card className="w-full max-w-lg" onClick={e => e.stopPropagation()}>
+        <h3 className="text-lg font-bold mb-4">{clientToEdit ? 'Edit Client' : 'Add New Client'}</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Client Name"
+            className="w-full p-2 border rounded"
+            required
+          />
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder="Contact Email"
+            className="w-full p-2 border rounded"
+            required
+          />
+          <input
+            type="tel"
+            value={phone}
+            onChange={e => setPhone(e.target.value)}
+            placeholder="Contact Phone"
+            className="w-full p-2 border rounded"
+            required
+          />
+          <textarea
+            value={address}
+            onChange={e => setAddress(e.target.value)}
+            placeholder="Billing Address"
+            className="w-full p-2 border rounded"
+            rows={3}
+            required
+          />
+          <input
+            type="text"
+            value={terms}
+            onChange={e => setTerms(e.target.value)}
+            placeholder="Payment Terms (e.g., Net 30)"
+            className="w-full p-2 border rounded"
+            required
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={onClose} type="button">
+              Cancel
+            </Button>
+            <Button type="submit" isLoading={isSaving}>
+              Save Client
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
 };
 
+const InvoiceModal: React.FC<{
+  invoiceToEdit?: Invoice | null;
+  isReadOnly?: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  user: User;
+  clients: Client[];
+  projects: Project[];
+  addToast: (message: string, type: 'success' | 'error') => void;
+}> = ({ invoiceToEdit, isReadOnly = false, onClose, onSuccess, user, clients, projects, addToast }) => {
+  const [clientId, setClientId] = useState<string>(invoiceToEdit?.clientId?.toString() || '');
+  const [projectId, setProjectId] = useState<string>(invoiceToEdit?.projectId?.toString() || '');
+  const [issuedAt, setIssuedAt] = useState(new Date(invoiceToEdit?.issuedAt || new Date()).toISOString().split('T')[0]);
+  const [dueAt, setDueAt] = useState(
+    new Date(invoiceToEdit?.dueAt || Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+  );
+  const [lineItems, setLineItems] = useState<InvoiceLineItemDraft[]>(() =>
+    invoiceToEdit?.lineItems?.length
+      ? invoiceToEdit.lineItems.map(mapInvoiceLineItemToDraft)
+      : [createLineItemDraft()],
+  );
+  const [taxRate, setTaxRate] = useState<number | ''>(invoiceToEdit ? invoiceToEdit.taxRate * 100 : 20);
+  const [retentionRate, setRetentionRate] = useState<number | ''>(invoiceToEdit ? invoiceToEdit.retentionRate * 100 : 5);
+  const [notes, setNotes] = useState(invoiceToEdit?.notes || '');
+  const [isSaving, setIsSaving] = useState(false);
 
-// --- Main View ---
-
-export const FinancialsView: React.FC<{ user: User; addToast: (message: string, type: 'success' | 'error') => void; }> = ({ user, addToast }) => {
-    const [activeTab, setActiveTab] = useState<FinancialsTab>('dashboard');
-    const [loading, setLoading] = useState(true);
-    const [data, setData] = useState({
-        kpis: null as FinancialKPIs | null,
-        monthly: [] as MonthlyFinancials[],
-        costs: [] as CostBreakdown[],
-        invoices: [] as Invoice[],
-        quotes: [] as Quote[],
-        expenses: [] as Expense[],
-        clients: [] as Client[],
-        projects: [] as Project[],
-        users: [] as User[],
-    });
-
-    const [modal, setModal] = useState<'client' | 'invoice' | 'payment' | 'expense' | null>(null);
-    const [selectedItem, setSelectedItem] = useState<Client | Invoice | Expense | null>(null);
-    const abortControllerRef = useRef<AbortController | null>(null);
-
-    const canManageFinances = hasPermission(user, Permission.MANAGE_FINANCES);
-
-    const fetchData = useCallback(async () => {
-        const controller = new AbortController();
-        abortControllerRef.current?.abort();
-        abortControllerRef.current = controller;
-
-        if (!user.companyId) return;
-        setLoading(true);
-        try {
-            const [kpiData, monthlyData, costsData, invoiceData, quoteData, expenseData, clientData, projectData, usersData] = await Promise.all([
-                api.getFinancialKPIsForCompany(user.companyId, { signal: controller.signal }),
-                api.getMonthlyFinancials(user.companyId, { signal: controller.signal }),
-                api.getCostBreakdown(user.companyId, { signal: controller.signal }),
-                api.getInvoicesByCompany(user.companyId, { signal: controller.signal }),
-                api.getQuotesByCompany(user.companyId, { signal: controller.signal }),
-                api.getExpensesByCompany(user.companyId, { signal: controller.signal }),
-                api.getClientsByCompany(user.companyId, { signal: controller.signal }),
-                api.getProjectsByCompany(user.companyId, { signal: controller.signal }),
-                api.getUsersByCompany(user.companyId, { signal: controller.signal }),
-            ]);
-            if (controller.signal.aborted) return;
-            setData({ kpis: kpiData, monthly: monthlyData, costs: costsData, invoices: invoiceData, quotes: quoteData, expenses: expenseData, clients: clientData, projects: projectData, users: usersData });
-        } catch (error) {
-            if (controller.signal.aborted) return;
-            addToast("Failed to load financial data", 'error');
-        } finally {
-            if (controller.signal.aborted) return;
-            setLoading(false);
-        }
-    }, [user.companyId, addToast]);
-
-    useEffect(() => {
-        fetchData();
-        return () => {
-            abortControllerRef.current?.abort();
-        };
-    }, [fetchData]);
-
-    const { projectMap, clientMap, userMap } = useMemo(() => ({
-        projectMap: new Map(data.projects.map(p => [p.id, p.name])),
-        clientMap: new Map(data.clients.map(c => [c.id, c.name])),
-        userMap: new Map(data.users.map(u => [u.id, `${u.firstName} ${u.lastName}`]))
-    }), [data.projects, data.clients, data.users]);
-
-    const handleUpdateInvoiceStatus = useCallback(async (invoiceId: string, status: InvoiceStatus) => {
-        if (status === InvoiceStatus.CANCELLED) {
-            if (!window.confirm("Are you sure you want to cancel this invoice? This action cannot be undone.")) {
-                return;
-            }
-        }
-        try {
-            const invoice = data.invoices.find(i => i.id === invoiceId);
-            if (!invoice) throw new Error("Invoice not found");
-            await api.updateInvoice(invoiceId, { ...invoice, status }, user.id);
-            addToast(`Invoice marked as ${status.toLowerCase()}.`, 'success');
-            fetchData();
-        } catch (error) {
-            addToast("Failed to update invoice status.", "error");
-        }
-    }, [data.invoices, user.id, addToast, fetchData]);
-
-    const handleCreateInvoice = useCallback(() => {
-        setSelectedItem(null);
-        setModal('invoice');
-    }, [setSelectedItem, setModal]);
-
-    const handleOpenInvoice = useCallback((invoice: Invoice) => {
-        setSelectedItem(invoice);
-        setModal('invoice');
-    }, [setSelectedItem, setModal]);
-
-    const handleRecordPayment = useCallback((invoice: Invoice) => {
-        setSelectedItem(invoice);
-        setModal('payment');
-    }, [setSelectedItem, setModal]);
-
-    const handleCreateExpense = useCallback(() => {
-        setSelectedItem(null);
-        setModal('expense');
-    }, [setSelectedItem, setModal]);
-
-    const handleEditExpense = useCallback((expense: Expense) => {
-        setSelectedItem(expense);
-        setModal('expense');
-    }, [setSelectedItem, setModal]);
-
-    const handleAddClient = useCallback(() => {
-        setSelectedItem(null);
-        setModal('client');
-    }, [setSelectedItem, setModal]);
-
-    const handleEditClient = useCallback((client: Client) => {
-        setSelectedItem(client);
-        setModal('client');
-    }, [setSelectedItem, setModal]);
-
-
-    if (loading) return <Card>Loading financials...</Card>;
-
-    const selectedInvoice = modal === 'invoice' || modal === 'payment' ? (selectedItem as Invoice) : null;
-    const isInvoiceReadOnly = !canManageFinances || selectedInvoice?.status === InvoiceStatus.PAID || selectedInvoice?.status === InvoiceStatus.CANCELLED;
-
-    return (
-        <div className="space-y-6">
-            {modal === 'client' && <ClientModal clientToEdit={selectedItem as Client} onClose={() => setModal(null)} onSuccess={fetchData} user={user} addToast={addToast} />}
-            {modal === 'invoice' && <InvoiceModal invoiceToEdit={selectedInvoice} isReadOnly={isInvoiceReadOnly} onClose={() => setModal(null)} onSuccess={fetchData} user={user} clients={data.clients} projects={data.projects} addToast={addToast} />}
-            {modal === 'payment' && selectedInvoice && <PaymentModal invoice={selectedInvoice} balance={getInvoiceFinancials(selectedInvoice).balance} onClose={() => setModal(null)} onSuccess={fetchData} user={user} addToast={addToast} />}
-            {modal === 'expense' && <ExpenseModal expenseToEdit={selectedItem as Expense} onClose={() => setModal(null)} onSuccess={fetchData} user={user} projects={data.projects} addToast={addToast} />}
-
-            <div className="flex justify-between items-center">
-                <h2 className="text-3xl font-bold">Financials</h2>
-            </div>
-             <div className="border-b border-border">
-                <nav className="-mb-px flex space-x-6 overflow-x-auto">
-                    {(['dashboard', 'invoices', 'expenses', 'clients'] as FinancialsTab[]).map(tab => (
-                         <button key={tab} onClick={() => setActiveTab(tab)} className={`capitalize whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm transition-colors ${activeTab === tab ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}>
-                            {tab}
-                        </button>
-                    ))}
-                </nav>
-            </div>
-            {activeTab === 'dashboard' && (
-                <DashboardTab kpis={data.kpis} monthly={data.monthly} costs={data.costs} />
-            )}
-            {activeTab === 'invoices' && (
-                <InvoicesTab
-                    invoices={data.invoices}
-                    quotes={data.quotes}
-                    canManageFinances={canManageFinances}
-                    clientMap={clientMap}
-                    projectMap={projectMap}
-                    onCreateInvoice={handleCreateInvoice}
-                    onOpenInvoice={handleOpenInvoice}
-                    onRecordPayment={handleRecordPayment}
-                    onUpdateInvoiceStatus={handleUpdateInvoiceStatus}
-                />
-            )}
-            {activeTab === 'expenses' && (
-                <ExpensesTab
-                    expenses={data.expenses}
-                    userMap={userMap}
-                    projectMap={projectMap}
-                    onCreateExpense={handleCreateExpense}
-                    onEditExpense={handleEditExpense}
-                />
-            )}
-            {activeTab === 'clients' && (
-                <ClientsTab
-                    clients={data.clients}
-                    canManageFinances={canManageFinances}
-                    onAddClient={handleAddClient}
-                    onEditClient={handleEditClient}
-                />
-            )}
-        </div>
+  useEffect(() => {
+    setLineItems(
+      invoiceToEdit?.lineItems?.length
+        ? invoiceToEdit.lineItems.map(mapInvoiceLineItemToDraft)
+        : [createLineItemDraft()],
     );
+  }, [invoiceToEdit?.id]);
+
+  const handleLineItemChange = <Field extends EditableInvoiceLineItemField>(
+    index: number,
+    field: Field,
+    value: InvoiceLineItemDraft[Field],
+  ) => {
+    setLineItems(prevItems => prevItems.map((item, itemIndex) => (itemIndex === index ? { ...item, [field]: value } : item)));
+  };
+
+  const addLineItem = () => setLineItems(prevItems => [...prevItems, createLineItemDraft()]);
+  const removeLineItem = (index: number) =>
+    setLineItems(prevItems => prevItems.filter((_, itemIndex) => itemIndex !== index));
+
+  const { subtotal, taxAmount, retentionAmount, total } = useMemo(() => {
+    const subtotalCalc = lineItems.reduce((acc, item) => acc + item.quantity * item.unitPrice, 0);
+    const taxPercentage = typeof taxRate === 'number' ? taxRate : 0;
+    const retentionPercentage = typeof retentionRate === 'number' ? retentionRate : 0;
+    const taxAmountCalc = subtotalCalc * (taxPercentage / 100);
+    const retentionAmountCalc = subtotalCalc * (retentionPercentage / 100);
+    const totalCalc = subtotalCalc + taxAmountCalc - retentionAmountCalc;
+    return { subtotal: subtotalCalc, taxAmount: taxAmountCalc, retentionAmount: retentionAmountCalc, total: totalCalc };
+  }, [lineItems, taxRate, retentionRate]);
+
+  const amountPaid = invoiceToEdit?.amountPaid || 0;
+  const balance = total - amountPaid;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSaving(true);
+    try {
+      const finalLineItems = lineItems.reduce<InvoiceLineItem[]>((acc, item) => {
+        const description = item.description.trim();
+        const quantity = Math.max(item.quantity, 0);
+        const unitPrice = Math.max(item.unitPrice, 0);
+
+        if (!description || quantity <= 0 || unitPrice <= 0) {
+          return acc;
+        }
+
+        acc.push({
+          id: item.id.startsWith('new-') ? String(Date.now() + Math.random()) : item.id,
+          description,
+          quantity,
+          unitPrice,
+          rate: unitPrice,
+          amount: quantity * unitPrice,
+        });
+
+        return acc;
+      }, []);
+
+      const invoiceData = {
+        clientId,
+        projectId,
+        issuedAt: new Date(issuedAt).toISOString(),
+        dueAt: new Date(dueAt).toISOString(),
+        lineItems: finalLineItems,
+        taxRate: Number(taxRate) / 100,
+        retentionRate: Number(retentionRate) / 100,
+        notes,
+        subtotal,
+        taxAmount,
+        retentionAmount,
+        total,
+        amountPaid,
+        balance,
+        payments: invoiceToEdit?.payments || [],
+        status: invoiceToEdit?.status || InvoiceStatus.DRAFT,
+      };
+
+      if (invoiceToEdit) {
+        const updated = await api.updateInvoice(
+          invoiceToEdit.id,
+          { ...invoiceData, invoiceNumber: invoiceToEdit.invoiceNumber },
+          user.id,
+        );
+        addToast(`Invoice ${updated.invoiceNumber} updated.`, 'success');
+      } else {
+        const created = await api.createInvoice(invoiceData, user.id);
+        if (!created.invoiceNumber) {
+          throw new Error('Invoice number was not returned by the server.');
+        }
+        addToast(`Invoice ${created.invoiceNumber} created as draft.`, 'success');
+      }
+      onSuccess();
+      onClose();
+    } catch (error) {
+      const message = error instanceof Error && error.message ? error.message : 'Failed to save invoice.';
+      addToast(message, 'error');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4" onClick={onClose}>
+      <Card className="w-full max-w-4xl max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <h3 className="text-lg font-bold mb-4">
+          {invoiceToEdit ? `${isReadOnly ? 'View' : 'Edit'} Invoice ${invoiceToEdit.invoiceNumber}` : 'Create Invoice'}
+        </h3>
+        <form onSubmit={handleSubmit} className="space-y-4 overflow-y-auto pr-2 flex-grow">
+          <div className="grid grid-cols-2 gap-4">
+            <select
+              value={clientId}
+              onChange={e => setClientId(e.target.value)}
+              className="w-full p-2 border rounded bg-white dark:bg-slate-800"
+              required
+              disabled={isReadOnly}
+            >
+              <option value="">Select Client</option>
+              {clients.map(client => (
+                <option key={client.id} value={client.id}>
+                  {client.name}
+                </option>
+              ))}
+            </select>
+            <select
+              value={projectId}
+              onChange={e => setProjectId(e.target.value)}
+              className="w-full p-2 border rounded bg-white dark:bg-slate-800"
+              required
+              disabled={isReadOnly}
+            >
+              <option value="">Select Project</option>
+              {projects.map(project => (
+                <option key={project.id} value={project.id}>
+                  {project.name}
+                </option>
+              ))}
+            </select>
+            <div>
+              <label className="text-xs">Issued Date</label>
+              <input
+                type="date"
+                value={issuedAt}
+                onChange={e => setIssuedAt(e.target.value)}
+                className="w-full p-2 border rounded"
+                disabled={isReadOnly}
+              />
+            </div>
+            <div>
+              <label className="text-xs">Due Date</label>
+              <input
+                type="date"
+                value={dueAt}
+                onChange={e => setDueAt(e.target.value)}
+                className="w-full p-2 border rounded"
+                disabled={isReadOnly}
+              />
+            </div>
+          </div>
+          <div className="border-t pt-2">
+            <h4 className="font-semibold">Line Items</h4>
+            <div className="grid grid-cols-[1fr,90px,130px,130px,40px] gap-2 items-center mt-1 text-xs text-muted-foreground">
+              <span>Description</span>
+              <span className="text-right">Quantity</span>
+              <span className="text-right">Unit Price</span>
+              <span className="text-right">Amount</span>
+            </div>
+            {lineItems.map((item, index) => (
+              <div key={item.id} className="grid grid-cols-[1fr,90px,130px,130px,40px] gap-2 items-center mt-2">
+                <input
+                  type="text"
+                  value={item.description}
+                  onChange={e => handleLineItemChange(index, 'description', e.target.value)}
+                  placeholder="Item or service description"
+                  className="p-1 border rounded"
+                  disabled={isReadOnly}
+                />
+                <input
+                  type="number"
+                  value={item.quantity}
+                  onChange={e => handleLineItemChange(index, 'quantity', parseNumberInputValue(e.target.value))}
+                  placeholder="1"
+                  className="p-1 border rounded text-right"
+                  disabled={isReadOnly}
+                />
+                <input
+                  type="number"
+                  value={item.unitPrice}
+                  onChange={e => handleLineItemChange(index, 'unitPrice', parseNumberInputValue(e.target.value))}
+                  placeholder="0.00"
+                  className="p-1 border rounded text-right"
+                  disabled={isReadOnly}
+                />
+                <span className="p-1 text-right font-medium">{formatCurrency(item.quantity * item.unitPrice)}</span>
+                {!isReadOnly && (
+                  <Button type="button" variant="danger" size="sm" onClick={() => removeLineItem(index)}>
+                    &times;
+                  </Button>
+                )}
+              </div>
+            ))}
+            {!isReadOnly && (
+              <Button type="button" variant="secondary" size="sm" className="mt-2" onClick={addLineItem}>
+                + Add Item
+              </Button>
+            )}
+          </div>
+          <div className="border-t pt-4 grid grid-cols-2 gap-8">
+            <div>
+              <h4 className="font-semibold mb-2">Notes</h4>
+              <textarea
+                value={notes}
+                onChange={e => setNotes(e.target.value)}
+                placeholder="Payment details, terms and conditions..."
+                rows={6}
+                className="p-2 border rounded w-full"
+                disabled={isReadOnly}
+              />
+            </div>
+            <div className="space-y-2">
+              <h4 className="font-semibold mb-2">Totals</h4>
+              <div className="flex justify-between items-center">
+                <span className="text-sm">Subtotal:</span>
+                <span className="font-medium">{formatCurrency(subtotal)}</span>
+              </div>
+              <div className="flex justify-between items-center">
+                <label htmlFor="taxRate" className="text-sm">
+                  Tax (%):
+                </label>
+                <input
+                  id="taxRate"
+                  type="number"
+                  value={taxRate}
+                  onChange={e => setTaxRate(e.target.value === '' ? '' : Number(e.target.value))}
+                  className="w-24 p-1 border rounded text-right"
+                  disabled={isReadOnly}
+                />
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-muted-foreground">Tax Amount:</span>
+                <span>{formatCurrency(taxAmount)}</span>
+              </div>
+              <div className="flex justify-between items-center">
+                <label htmlFor="retentionRate" className="text-sm">
+                  Retention (%):
+                </label>
+                <input
+                  id="retentionRate"
+                  type="number"
+                  value={retentionRate}
+                  onChange={e => setRetentionRate(e.target.value === '' ? '' : Number(e.target.value))}
+                  className="w-24 p-1 border rounded text-right"
+                  disabled={isReadOnly}
+                />
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-red-600">Retention Held:</span>
+                <span className="text-red-600 font-medium">-{formatCurrency(retentionAmount)}</span>
+              </div>
+              <div className="flex justify-between items-center font-bold text-lg pt-2 border-t">
+                <span>Total Due:</span>
+                <span>{formatCurrency(total)}</span>
+              </div>
+              {invoiceToEdit && (
+                <>
+                  <div className="flex justify-between items-center text-sm">
+                    <span>Amount Paid:</span>
+                    <span>-{formatCurrency(amountPaid)}</span>
+                  </div>
+                  <div className="flex justify-between items-center font-bold text-lg text-green-600">
+                    <span>Balance:</span>
+                    <span>{formatCurrency(balance)}</span>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </form>
+        <div className="flex justify-end gap-2 pt-4 border-t mt-4 flex-shrink-0">
+          <Button variant="secondary" onClick={onClose}>
+            {isReadOnly ? 'Close' : 'Cancel'}
+          </Button>
+          {!isReadOnly && (
+            <Button type="submit" isLoading={isSaving} onClick={handleSubmit}>
+              Save Invoice
+            </Button>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+const PaymentModal: React.FC<{
+  invoice: Invoice;
+  balance: number;
+  onClose: () => void;
+  onSuccess: () => void;
+  user: User;
+  addToast: (message: string, type: 'success' | 'error') => void;
+}> = ({ invoice, balance, onClose, onSuccess, user, addToast }) => {
+  const [amount, setAmount] = useState<number | ''>(balance > 0 ? balance : '');
+  const [method, setMethod] = useState<'CREDIT_CARD' | 'BANK_TRANSFER' | 'CASH'>('BANK_TRANSFER');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSubmit = async () => {
+    const numericAmount = Number(amount);
+    if (amount === '' || numericAmount <= 0) {
+      addToast('Invalid amount', 'error');
+      return;
+    }
+    if (numericAmount > balance) {
+      addToast('Amount exceeds the outstanding balance', 'error');
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await api.recordPaymentForInvoice(invoice.id, { amount: numericAmount, method }, user.id);
+      addToast('Payment recorded.', 'success');
+      onSuccess();
+      onClose();
+    } catch (error) {
+      addToast('Failed to record payment.', 'error');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4" onClick={onClose}>
+      <Card className="w-full max-w-md" onClick={e => e.stopPropagation()}>
+        <h3 className="text-lg font-bold">Record Payment for {invoice.invoiceNumber}</h3>
+        <p className="text-sm text-muted-foreground mb-4">Current balance: {formatCurrency(balance)}</p>
+        <input
+          type="number"
+          value={amount}
+          onChange={e => setAmount(e.target.value === '' ? '' : Number(e.target.value))}
+          placeholder={`Enter amount (up to ${balance.toFixed(2)})`}
+          className="w-full p-2 border rounded mt-4"
+          max={balance}
+        />
+        <select
+          value={method}
+          onChange={e => setMethod(e.target.value as typeof method)}
+          className="w-full p-2 border rounded mt-2 bg-white"
+        >
+          <option value="BANK_TRANSFER">Bank Transfer</option>
+          <option value="CREDIT_CARD">Card</option>
+          <option value="CASH">Cash</option>
+        </select>
+        <div className="flex justify-end gap-2 mt-4">
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} isLoading={isSaving}>
+            Record Payment
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+const BarChart: React.FC<{ data: { label: string; value: number }[]; barColor: string }> = ({ data, barColor }) => {
+  const maxValue = Math.max(...data.map(d => d.value), 0);
+  return (
+    <div className="w-full h-64 flex items-end justify-around p-4 border rounded-lg bg-slate-50 dark:bg-slate-800">
+      {data.map((item, index) => (
+        <div key={index} className="flex flex-col items-center justify-end h-full w-full">
+          <div
+            className={`w-3/4 rounded-t-md ${barColor}`}
+            style={{ height: `${maxValue > 0 ? (item.value / maxValue) * 100 : 0}%` }}
+            title={formatCurrency(item.value)}
+          ></div>
+          <span className="text-xs mt-2 text-slate-600">{item.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const FinancialsView: React.FC<{ user: User; addToast: (message: string, type: 'success' | 'error') => void }> = ({
+  user,
+  addToast,
+}) => {
+  const [activeTab, setActiveTab] = useState<FinancialsTab>('dashboard');
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState({
+    kpis: null as FinancialKPIs | null,
+    monthly: [] as MonthlyFinancials[],
+    costs: [] as CostBreakdown[],
+    invoices: [] as Invoice[],
+    quotes: [] as Quote[],
+    expenses: [] as Expense[],
+    clients: [] as Client[],
+    projects: [] as Project[],
+    users: [] as User[],
+    forecasts: [] as FinancialForecast[],
+    companyName: null as string | null,
+  });
+  const [modal, setModal] = useState<'client' | 'invoice' | 'payment' | 'expense' | null>(null);
+  const [selectedItem, setSelectedItem] = useState<Client | Invoice | Expense | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const [isGeneratingForecast, setIsGeneratingForecast] = useState(false);
+  const [forecastError, setForecastError] = useState<string | null>(null);
+
+  const canManageFinances = hasPermission(user, Permission.MANAGE_FINANCES);
+
+  const fetchData = useCallback(async () => {
+    const controller = new AbortController();
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = controller;
+
+    if (!user.companyId) return;
+    setLoading(true);
+    try {
+      const [
+        kpiData,
+        monthlyData,
+        costsData,
+        invoiceData,
+        quoteData,
+        expenseData,
+        clientData,
+        projectData,
+        usersData,
+        forecastData,
+        companyData,
+      ] = await Promise.all([
+        api.getFinancialKPIsForCompany(user.companyId, { signal: controller.signal }),
+        api.getMonthlyFinancials(user.companyId, { signal: controller.signal }),
+        api.getCostBreakdown(user.companyId, { signal: controller.signal }),
+        api.getInvoicesByCompany(user.companyId, { signal: controller.signal }),
+        api.getQuotesByCompany(user.companyId, { signal: controller.signal }),
+        api.getExpensesByCompany(user.companyId, { signal: controller.signal }),
+        api.getClientsByCompany(user.companyId, { signal: controller.signal }),
+        api.getProjectsByCompany(user.companyId, { signal: controller.signal }),
+        api.getUsersByCompany(user.companyId, { signal: controller.signal }),
+        api.getFinancialForecasts(user.companyId, { signal: controller.signal }),
+        api.getCompanies({ signal: controller.signal }),
+      ]);
+      if (controller.signal.aborted) return;
+      const companyRecord = companyData.find((company: { id?: string }) => company.id === user.companyId) as
+        | { name?: string }
+        | undefined;
+      setData({
+        kpis: kpiData,
+        monthly: monthlyData,
+        costs: costsData,
+        invoices: invoiceData,
+        quotes: quoteData,
+        expenses: expenseData,
+        clients: clientData,
+        projects: projectData,
+        users: usersData,
+        forecasts: forecastData,
+        companyName: companyRecord?.name ?? null,
+      });
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      addToast('Failed to load financial data', 'error');
+    } finally {
+      if (controller.signal.aborted) return;
+      setLoading(false);
+    }
+  }, [user.companyId, addToast]);
+
+  useEffect(() => {
+    fetchData();
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, [fetchData]);
+
+  const { projectMap, clientMap, userMap } = useMemo(
+    () => ({
+      projectMap: new Map(data.projects.map(p => [p.id, p.name])),
+      clientMap: new Map(data.clients.map(c => [c.id, c.name])),
+      userMap: new Map(data.users.map(u => [u.id, `${u.firstName} ${u.lastName}`])),
+    }),
+    [data.projects, data.clients, data.users],
+  );
+
+  const handleUpdateInvoiceStatus = useCallback(
+    async (invoiceId: string, status: InvoiceStatus) => {
+      if (status === InvoiceStatus.CANCELLED) {
+        if (!window.confirm('Are you sure you want to cancel this invoice? This action cannot be undone.')) {
+          return;
+        }
+      }
+      try {
+        const invoice = data.invoices.find(i => i.id === invoiceId);
+        if (!invoice) throw new Error('Invoice not found');
+        await api.updateInvoice(invoiceId, { ...invoice, status }, user.id);
+        addToast(`Invoice marked as ${status.toLowerCase()}.`, 'success');
+        fetchData();
+      } catch (error) {
+        addToast('Failed to update invoice status.', 'error');
+      }
+    },
+    [data.invoices, user.id, addToast, fetchData],
+  );
+
+  const handleGenerateForecast = useCallback(
+    async (horizonMonths: number) => {
+      if (!user.companyId) {
+        return;
+      }
+
+      const sanitizedHorizon = Number.isFinite(horizonMonths)
+        ? Math.max(1, Math.round(horizonMonths))
+        : 3;
+
+      setIsGeneratingForecast(true);
+      setForecastError(null);
+
+      try {
+        const forecast = await generateFinancialForecast({
+          companyName: data.companyName ?? 'Your company',
+          currency: data.kpis?.currency,
+          horizonMonths: sanitizedHorizon,
+          kpis: data.kpis,
+          monthly: data.monthly,
+          costs: data.costs,
+          invoices: data.invoices,
+          expenses: data.expenses,
+        });
+
+        const metadataRecord: Record<string, unknown> = { ...forecast.metadata };
+        const existingCurrency = metadataRecord['currency'];
+        metadataRecord['currency'] =
+          typeof existingCurrency === 'string'
+            ? existingCurrency
+            : data.kpis?.currency ?? 'GBP';
+        metadataRecord['horizonMonths'] = sanitizedHorizon;
+        metadataRecord['isFallback'] = forecast.isFallback;
+
+        const storedForecast = await api.createFinancialForecast(
+          {
+            companyId: user.companyId,
+            summary: forecast.summary,
+            horizonMonths: sanitizedHorizon,
+            metadata: metadataRecord,
+            model: forecast.model,
+          },
+          user.id,
+        );
+
+        setData(prev => ({ ...prev, forecasts: [storedForecast, ...prev.forecasts] }));
+        addToast('Financial forecast updated.', 'success');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to generate financial forecast.';
+        setForecastError(message);
+        addToast('Failed to generate financial forecast.', 'error');
+      } finally {
+        setIsGeneratingForecast(false);
+      }
+    },
+    [
+      user.companyId,
+      user.id,
+      data.companyName,
+      data.kpis,
+      data.monthly,
+      data.costs,
+      data.invoices,
+      data.expenses,
+      addToast,
+    ],
+  );
+
+  const handleCreateInvoice = useCallback(() => {
+    setSelectedItem(null);
+    setModal('invoice');
+  }, []);
+
+  const handleOpenInvoice = useCallback((invoice: Invoice) => {
+    setSelectedItem(invoice);
+    setModal('invoice');
+  }, []);
+
+  const handleRecordPayment = useCallback((invoice: Invoice) => {
+    setSelectedItem(invoice);
+    setModal('payment');
+  }, []);
+
+  const handleCreateExpense = useCallback(() => {
+    setSelectedItem(null);
+    setModal('expense');
+  }, []);
+
+  const handleEditExpense = useCallback((expense: Expense) => {
+    setSelectedItem(expense);
+    setModal('expense');
+  }, []);
+
+  const handleAddClient = useCallback(() => {
+    setSelectedItem(null);
+    setModal('client');
+  }, []);
+
+  const handleEditClient = useCallback((client: Client) => {
+    setSelectedItem(client);
+    setModal('client');
+  }, []);
+
+  if (loading) return <Card>Loading financials...</Card>;
+
+  const selectedInvoice = modal === 'invoice' || modal === 'payment' ? (selectedItem as Invoice) : null;
+  const isInvoiceReadOnly =
+    !canManageFinances ||
+    selectedInvoice?.status === InvoiceStatus.PAID ||
+    selectedInvoice?.status === InvoiceStatus.CANCELLED;
+
+  return (
+    <div className="space-y-6">
+      {modal === 'client' && (
+        <ClientModal
+          clientToEdit={selectedItem as Client}
+          onClose={() => setModal(null)}
+          onSuccess={fetchData}
+          user={user}
+          addToast={addToast}
+        />
+      )}
+      {modal === 'invoice' && (
+        <InvoiceModal
+          invoiceToEdit={selectedInvoice}
+          isReadOnly={isInvoiceReadOnly}
+          onClose={() => setModal(null)}
+          onSuccess={fetchData}
+          user={user}
+          clients={data.clients}
+          projects={data.projects}
+          addToast={addToast}
+        />
+      )}
+      {modal === 'payment' && selectedInvoice && (
+        <PaymentModal
+          invoice={selectedInvoice}
+          balance={getInvoiceFinancials(selectedInvoice).balance}
+          onClose={() => setModal(null)}
+          onSuccess={fetchData}
+          user={user}
+          addToast={addToast}
+        />
+      )}
+      {modal === 'expense' && (
+        <ExpenseModal
+          expenseToEdit={selectedItem as Expense}
+          onClose={() => setModal(null)}
+          onSuccess={fetchData}
+          user={user}
+          projects={data.projects}
+          addToast={addToast}
+        />
+      )}
+
+      <div className="flex justify-between items-center">
+        <h2 className="text-3xl font-bold">Financials</h2>
+      </div>
+      <div className="border-b border-border">
+        <nav className="-mb-px flex space-x-6 overflow-x-auto">
+          {(['dashboard', 'invoices', 'expenses', 'clients'] as FinancialsTab[]).map(tab => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`capitalize whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm transition-colors ${
+                activeTab === tab ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </nav>
+      </div>
+      {activeTab === 'dashboard' && (
+        <DashboardTab
+          kpis={data.kpis}
+          monthly={data.monthly}
+          costs={data.costs}
+          forecasts={data.forecasts}
+          onGenerateForecast={handleGenerateForecast}
+          isGeneratingForecast={isGeneratingForecast}
+          forecastError={forecastError}
+        />
+      )}
+      {activeTab === 'invoices' && (
+        <InvoicesTab
+          invoices={data.invoices}
+          quotes={data.quotes}
+          canManageFinances={canManageFinances}
+          clientMap={clientMap}
+          projectMap={projectMap}
+          onCreateInvoice={handleCreateInvoice}
+          onOpenInvoice={handleOpenInvoice}
+          onRecordPayment={handleRecordPayment}
+          onUpdateInvoiceStatus={handleUpdateInvoiceStatus}
+        />
+      )}
+      {activeTab === 'expenses' && (
+        <ExpensesTab
+          expenses={data.expenses}
+          userMap={userMap}
+          projectMap={projectMap}
+          onCreateExpense={handleCreateExpense}
+          onEditExpense={handleEditExpense}
+        />
+      )}
+      {activeTab === 'clients' && (
+        <ClientsTab
+          clients={data.clients}
+          canManageFinances={canManageFinances}
+          onAddClient={handleAddClient}
+          onEditClient={handleEditClient}
+        />
+      )}
+    </div>
+  );
 };
 
 interface DashboardTabProps {
-    kpis: FinancialKPIs | null;
-    monthly: MonthlyFinancials[];
-    costs: CostBreakdown[];
+  kpis: FinancialKPIs | null;
+  monthly: MonthlyFinancials[];
+  costs: CostBreakdown[];
+  forecasts: FinancialForecast[];
+  onGenerateForecast: (horizon: number) => void;
+  isGeneratingForecast: boolean;
+  forecastError: string | null;
 }
 
-const DashboardTab = React.memo(({ kpis, monthly, costs }: DashboardTabProps) => (
-    <div className="space-y-6">
+const DashboardTab = React.memo(
+  ({
+    kpis,
+    monthly,
+    costs,
+    forecasts,
+    onGenerateForecast,
+    isGeneratingForecast,
+    forecastError,
+  }: DashboardTabProps) => {
+    const [selectedHorizon, setSelectedHorizon] = useState(3);
+
+    const renderSummary = useCallback(
+      (summary: string, keyPrefix: string) =>
+        summary
+          .split('\n')
+          .map(line => line.trim())
+          .filter(line => line.length > 0)
+          .map((line, index) => (
+            <p
+              key={`${keyPrefix}-${index}`}
+              dangerouslySetInnerHTML={{
+                __html: line
+                  .replace(/\*\*(.*?)\*\*/g, '<strong class="font-semibold">$1</strong>')
+                  .replace(/^[-•]\s+/, '• '),
+              }}
+            />
+          )),
+      [],
+    );
+
+    const latestForecast = forecasts[0] ?? null;
+    const metadata = (latestForecast?.metadata ?? {}) as Record<string, unknown>;
+    const currencyValue = metadata['currency'];
+    const currency = typeof currencyValue === 'string' ? currencyValue : kpis?.currency ?? 'GBP';
+    const toNumber = (value: unknown): number | undefined =>
+      typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+    const averageProfit = toNumber(metadata['averageMonthlyProfit']);
+    const projectedCash = toNumber(metadata['projectedCash']);
+    const profitTrend = toNumber(metadata['profitTrendPct']);
+    const openInvoiceBalance = toNumber(metadata['openInvoiceBalance']);
+    const burnRate = toNumber(metadata['approvedExpenseRunRate']);
+    const tags: { label: string; value: string }[] = [];
+
+    const displayHorizon =
+      typeof latestForecast?.horizonMonths === 'number'
+        ? latestForecast.horizonMonths
+        : toNumber(metadata['horizonMonths']) ?? selectedHorizon;
+
+    if (typeof averageProfit === 'number') {
+      tags.push({ label: 'Avg monthly profit', value: formatCurrency(averageProfit, currency) });
+    }
+    if (typeof projectedCash === 'number') {
+      tags.push({ label: `${displayHorizon} mo cash`, value: formatCurrency(projectedCash, currency) });
+    }
+    if (typeof profitTrend === 'number') {
+      tags.push({ label: 'Trend', value: formatSignedPercentage(profitTrend) });
+    }
+    if (typeof openInvoiceBalance === 'number') {
+      tags.push({ label: 'Open invoices', value: formatCurrency(openInvoiceBalance, currency) });
+    }
+    if (typeof burnRate === 'number') {
+      tags.push({ label: 'Spend/mo', value: formatCurrency(burnRate, currency) });
+    }
+    if (metadata['isFallback'] === true) {
+      tags.push({ label: 'Mode', value: 'Offline summary' });
+    }
+
+    const previousForecasts = forecasts.slice(1, 5);
+
+    return (
+      <div className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <Card><p className="text-sm text-slate-500">Profitability</p><p className="text-3xl font-bold">{kpis?.profitability || 0}%</p></Card>
-            <Card><p className="text-sm text-slate-500">Avg. Project Margin</p><p className="text-3xl font-bold">{kpis?.projectMargin || 0}%</p></Card>
-            <Card><p className="text-sm text-slate-500">Cash Flow</p><p className="text-3xl font-bold">{formatCurrency(kpis?.cashFlow || 0, kpis?.currency)}</p></Card>
+          <Card>
+            <p className="text-sm text-slate-500">Profitability</p>
+            <p className="text-3xl font-bold">{kpis?.profitability || 0}%</p>
+          </Card>
+          <Card>
+            <p className="text-sm text-slate-500">Avg. Project Margin</p>
+            <p className="text-3xl font-bold">{kpis?.projectMargin || 0}%</p>
+          </Card>
+          <Card>
+            <p className="text-sm text-slate-500">Cash Flow</p>
+            <p className="text-3xl font-bold">{formatCurrency(kpis?.cashFlow || 0, kpis?.currency || 'GBP')}</p>
+          </Card>
         </div>
-         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-                <h3 className="font-semibold mb-4">Monthly Performance (Profit)</h3>
-                <BarChart data={monthly.map(m => ({ label: m.month, value: m.profit }))} barColor="bg-green-500" />
-            </Card>
-             <Card>
-                <h3 className="font-semibold mb-4">Cost Breakdown</h3>
-                <BarChart data={costs.map(c => ({ label: c.category, value: c.amount }))} barColor="bg-sky-500" />
-            </Card>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Card>
+            <h3 className="font-semibold mb-4">Monthly Performance (Profit)</h3>
+            <BarChart data={monthly.map(m => ({ label: m.month, value: m.profit }))} barColor="bg-green-500" />
+          </Card>
+          <Card>
+            <h3 className="font-semibold mb-4">Cost Breakdown</h3>
+            <BarChart data={costs.map(c => ({ label: c.category, value: c.amount }))} barColor="bg-sky-500" />
+          </Card>
         </div>
-    </div>
-));
+        <Card>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+              <div>
+                <h3 className="font-semibold text-lg">AI Cash Flow Outlook</h3>
+                <p className="text-sm text-muted-foreground">
+                  Generate a Gemini-powered forecast from recent invoices, expenses, and KPIs.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <select
+                  value={selectedHorizon}
+                  onChange={event => setSelectedHorizon(Number(event.target.value))}
+                  className="border border-input rounded-md px-2 py-1 text-sm bg-background"
+                  disabled={isGeneratingForecast}
+                >
+                  <option value={3}>Next 3 months</option>
+                  <option value={6}>Next 6 months</option>
+                  <option value={12}>Next 12 months</option>
+                </select>
+                <Button
+                  onClick={() => onGenerateForecast(selectedHorizon)}
+                  isLoading={isGeneratingForecast}
+                  disabled={isGeneratingForecast}
+                >
+                  {latestForecast ? 'Refresh Outlook' : 'Generate Outlook'}
+                </Button>
+              </div>
+            </div>
+            {forecastError && <p className="text-sm text-destructive">{forecastError}</p>}
+            {latestForecast ? (
+              <>
+                <div className="text-sm space-y-1 whitespace-pre-wrap">
+                  {renderSummary(latestForecast.summary, 'latest-forecast')}
+                </div>
+                {tags.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {tags.map(tag => (
+                      <span
+                        key={`${tag.label}-${tag.value}`}
+                        className="px-2 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium"
+                      >
+                        {tag.label}: {tag.value}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  Generated {new Date(latestForecast.createdAt).toLocaleString()}
+                  {latestForecast.model ? ` • ${latestForecast.model}` : ''}
+                  {metadata['isFallback'] === true ? ' • offline summary' : ''}
+                </p>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Run the assistant to model upcoming cash flow and profitability using live platform data.
+              </p>
+            )}
+            {previousForecasts.length > 0 && (
+              <details className="text-sm">
+                <summary className="cursor-pointer text-muted-foreground">Previous forecasts</summary>
+                <div className="mt-2 space-y-3 max-h-56 overflow-y-auto pr-1">
+                  {previousForecasts.map(forecast => {
+                    const entryMetadata = (forecast.metadata ?? {}) as Record<string, unknown>;
+                    return (
+                      <div key={forecast.id} className="border border-border rounded-md p-3 bg-background/60">
+                        <p className="text-xs text-muted-foreground">
+                          {new Date(forecast.createdAt).toLocaleString()}
+                          {forecast.model ? ` • ${forecast.model}` : ''}
+                          {entryMetadata['isFallback'] === true ? ' • offline summary' : ''}
+                        </p>
+                        <div className="text-xs space-y-1 whitespace-pre-wrap mt-1">
+                          {renderSummary(forecast.summary, forecast.id)}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </details>
+            )}
+          </div>
+        </Card>
+      </div>
+    );
+  },
+);
 
 DashboardTab.displayName = 'DashboardTab';
 
 interface InvoicesTabProps {
-    invoices: Invoice[];
-    quotes: Quote[];
-    canManageFinances: boolean;
-    clientMap: Map<string, string>;
-    projectMap: Map<string, string>;
-    onCreateInvoice: () => void;
-    onOpenInvoice: (invoice: Invoice) => void;
-    onRecordPayment: (invoice: Invoice) => void;
-    onUpdateInvoiceStatus: (invoiceId: string, status: InvoiceStatus) => void;
+  invoices: Invoice[];
+  quotes: Quote[];
+  canManageFinances: boolean;
+  clientMap: Map<string, string>;
+  projectMap: Map<string, string>;
+  onCreateInvoice: () => void;
+  onOpenInvoice: (invoice: Invoice) => void;
+  onRecordPayment: (invoice: Invoice) => void;
+  onUpdateInvoiceStatus: (invoiceId: string, status: InvoiceStatus) => void;
 }
 
-const InvoicesTab = React.memo(({ invoices, quotes, canManageFinances, clientMap, projectMap, onCreateInvoice, onOpenInvoice, onRecordPayment, onUpdateInvoiceStatus }: InvoicesTabProps) => (
+const InvoicesTab = React.memo(
+  ({ invoices, quotes, canManageFinances, clientMap, projectMap, onCreateInvoice, onOpenInvoice, onRecordPayment, onUpdateInvoiceStatus }: InvoicesTabProps) => (
     <div className="space-y-6">
-        <Card>
-            <div className="flex justify-between items-center mb-4">
-                <h3 className="font-semibold text-lg">Invoices</h3>
-                {canManageFinances && <Button onClick={onCreateInvoice}>Create Invoice</Button>}
-            </div>
-            <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-border">
-                    <thead className="bg-muted"><tr><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Number</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Client</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Project</th><th className="px-4 py-2 text-right text-xs font-medium text-muted-foreground uppercase">Total</th><th className="px-4 py-2 text-right text-xs font-medium text-muted-foreground uppercase">Balance Due</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Status</th><th className="px-4 py-2 text-right text-xs font-medium text-muted-foreground uppercase">Actions</th></tr></thead>
-                    <tbody className="bg-card divide-y divide-border">
-                        {invoices.map(invoice => {
-                            const { total, balance } = getInvoiceFinancials(invoice);
-                            const derivedStatus = getDerivedStatus(invoice);
-
-                            return (
-                            <tr key={invoice.id} className="hover:bg-accent">
-                                <td className="px-4 py-3 font-medium">{invoice.invoiceNumber}</td>
-                                <td className="px-4 py-3">{clientMap.get(invoice.clientId)}</td>
-                                <td className="px-4 py-3">{projectMap.get(invoice.projectId)}</td>
-                                <td className="px-4 py-3 text-right">{formatCurrency(total)}</td>
-                                <td className="px-4 py-3 text-right font-semibold">{formatCurrency(balance)}</td>
-                                <td className="px-4 py-3"><InvoiceStatusBadge status={derivedStatus} /></td>
-                                <td className="px-4 py-3 text-right space-x-2">
-                                    {canManageFinances && invoice.status === InvoiceStatus.DRAFT && (
-                                        <>
-                                            <Button size="sm" variant="success" onClick={() => onUpdateInvoiceStatus(invoice.id, InvoiceStatus.SENT)}>Send</Button>
-                                            <Button size="sm" variant="secondary" onClick={() => onOpenInvoice(invoice)}>Edit</Button>
-                                        </>
-                                    )}
-                                    {canManageFinances && (invoice.status === InvoiceStatus.SENT || derivedStatus === InvoiceStatus.OVERDUE) && (
-                                         <>
-                                            <Button size="sm" onClick={() => onRecordPayment(invoice)}>Record Payment</Button>
-                                            <Button size="sm" variant="danger" onClick={() => onUpdateInvoiceStatus(invoice.id, InvoiceStatus.CANCELLED)}>Cancel</Button>
-                                        </>
-                                    )}
-                                    {(invoice.status === InvoiceStatus.PAID || invoice.status === InvoiceStatus.CANCELLED) && (
-                                        <Button size="sm" variant="secondary" onClick={() => onOpenInvoice(invoice)}>View</Button>
-                                    )}
-                                </td>
-                            </tr>
-                        )})}
-                    </tbody>
-                </table>
-            </div>
-        </Card>
-         <Card>
-            <h3 className="font-semibold text-lg mb-4">Quotes</h3>
-             <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-border">
-                     <thead className="bg-muted"><tr><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Client</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Project</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Status</th></tr></thead>
-                      <tbody className="bg-card divide-y divide-border">
-                        {quotes.map(quote => (<tr key={quote.id}><td className="px-4 py-3">Client Name</td><td className="px-4 py-3">Project Name</td><td className="px-4 py-3"><QuoteStatusBadge status={quote.status} /></td></tr>))}
-                      </tbody>
-                </table>
-             </div>
-        </Card>
+      <Card>
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="font-semibold text-lg">Invoices</h3>
+          {canManageFinances && <Button onClick={onCreateInvoice}>Create Invoice</Button>}
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-border">
+            <thead className="bg-muted">
+              <tr>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Number</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Client</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Project</th>
+                <th className="px-4 py-2 text-right text-xs font-medium text-muted-foreground uppercase">Total</th>
+                <th className="px-4 py-2 text-right text-xs font-medium text-muted-foreground uppercase">Balance Due</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Status</th>
+                <th className="px-4 py-2 text-right text-xs font-medium text-muted-foreground uppercase">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="bg-card divide-y divide-border">
+              {invoices.map(invoice => {
+                const { total, balance } = getInvoiceFinancials(invoice);
+                const derivedStatus = getDerivedStatus(invoice);
+                return (
+                  <tr key={invoice.id} className="hover:bg-accent">
+                    <td className="px-4 py-3 font-medium">{invoice.invoiceNumber}</td>
+                    <td className="px-4 py-3">{clientMap.get(invoice.clientId)}</td>
+                    <td className="px-4 py-3">{projectMap.get(invoice.projectId)}</td>
+                    <td className="px-4 py-3 text-right">{formatCurrency(total)}</td>
+                    <td className="px-4 py-3 text-right font-semibold">{formatCurrency(balance)}</td>
+                    <td className="px-4 py-3">
+                      <InvoiceStatusBadge status={derivedStatus} />
+                    </td>
+                    <td className="px-4 py-3 text-right space-x-2">
+                      {canManageFinances && invoice.status === InvoiceStatus.DRAFT && (
+                        <>
+                          <Button size="sm" variant="success" onClick={() => onUpdateInvoiceStatus(invoice.id, InvoiceStatus.SENT)}>
+                            Send
+                          </Button>
+                          <Button size="sm" variant="secondary" onClick={() => onOpenInvoice(invoice)}>
+                            Edit
+                          </Button>
+                        </>
+                      )}
+                      {canManageFinances &&
+                        (invoice.status === InvoiceStatus.SENT || derivedStatus === InvoiceStatus.OVERDUE) && (
+                          <>
+                            <Button size="sm" onClick={() => onRecordPayment(invoice)}>
+                              Record Payment
+                            </Button>
+                            <Button size="sm" variant="danger" onClick={() => onUpdateInvoiceStatus(invoice.id, InvoiceStatus.CANCELLED)}>
+                              Cancel
+                            </Button>
+                          </>
+                        )}
+                      {(invoice.status === InvoiceStatus.PAID || invoice.status === InvoiceStatus.CANCELLED) && (
+                        <Button size="sm" variant="secondary" onClick={() => onOpenInvoice(invoice)}>
+                          View
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+      <Card>
+        <h3 className="font-semibold text-lg mb-4">Quotes</h3>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-border">
+            <thead className="bg-muted">
+              <tr>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Client</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Project</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Status</th>
+              </tr>
+            </thead>
+            <tbody className="bg-card divide-y divide-border">
+              {quotes.map(quote => (
+                <tr key={quote.id}>
+                  <td className="px-4 py-3">{clientMap.get(quote.id) ?? 'Client'}</td>
+                  <td className="px-4 py-3">{projectMap.get(quote.id) ?? 'Project'}</td>
+                  <td className="px-4 py-3">
+                    <QuoteStatusBadge status={quote.status} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
     </div>
-));
+  ),
+);
 
 InvoicesTab.displayName = 'InvoicesTab';
 
 interface ExpensesTabProps {
-    expenses: Expense[];
-    userMap: Map<string, string>;
-    projectMap: Map<string, string>;
-    onCreateExpense: () => void;
-    onEditExpense: (expense: Expense) => void;
+  expenses: Expense[];
+  userMap: Map<string, string>;
+  projectMap: Map<string, string>;
+  onCreateExpense: () => void;
+  onEditExpense: (expense: Expense) => void;
 }
 
 const ExpensesTab = React.memo(({ expenses, userMap, projectMap, onCreateExpense, onEditExpense }: ExpensesTabProps) => (
-    <Card>
-         <div className="flex justify-between items-center mb-4">
-            <h3 className="font-semibold text-lg">Expenses</h3>
-            <Button onClick={onCreateExpense}>Submit Expense</Button>
-        </div>
-        <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-border">
-                <thead className="bg-muted"><tr><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Date</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Submitted By</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Project</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Description</th><th className="px-4 py-2 text-right text-xs font-medium text-muted-foreground uppercase">Amount</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Status</th><th className="px-4 py-2 text-right text-xs font-medium text-muted-foreground uppercase">Actions</th></tr></thead>
-                <tbody className="bg-card divide-y divide-border">
-                    {expenses.map(exp => (
-                        <tr key={exp.id}>
-                            <td className="px-4 py-3">{new Date(exp.submittedAt).toLocaleDateString()}</td>
-                            <td className="px-4 py-3">{userMap.get(exp.userId)}</td>
-                            <td className="px-4 py-3">{projectMap.get(exp.projectId)}</td>
-                            <td className="px-4 py-3">{exp.description}</td>
-                            <td className="px-4 py-3 text-right">{formatCurrency(exp.amount)}</td>
-                            <td className="px-4 py-3"><Tag label={exp.status} color={exp.status === 'APPROVED' ? 'green' : exp.status === 'REJECTED' ? 'red' : 'yellow'} /></td>
-                            <td className="px-4 py-3 text-right">{exp.status === 'REJECTED' && <Button size="sm" variant="secondary" onClick={() => onEditExpense(exp)}>Edit & Resubmit</Button>}</td>
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
-        </div>
-    </Card>
+  <Card>
+    <div className="flex justify-between items-center mb-4">
+      <h3 className="font-semibold text-lg">Expenses</h3>
+      <Button onClick={onCreateExpense}>Submit Expense</Button>
+    </div>
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-border">
+        <thead className="bg-muted">
+          <tr>
+            <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Date</th>
+            <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Submitted By</th>
+            <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Project</th>
+            <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Description</th>
+            <th className="px-4 py-2 text-right text-xs font-medium text-muted-foreground uppercase">Amount</th>
+            <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Status</th>
+            <th className="px-4 py-2 text-right text-xs font-medium text-muted-foreground uppercase">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="bg-card divide-y divide-border">
+          {expenses.map(exp => (
+            <tr key={exp.id}>
+              <td className="px-4 py-3">{new Date(exp.submittedAt).toLocaleDateString()}</td>
+              <td className="px-4 py-3">{userMap.get(exp.userId)}</td>
+              <td className="px-4 py-3">{projectMap.get(exp.projectId)}</td>
+              <td className="px-4 py-3">{exp.description}</td>
+              <td className="px-4 py-3 text-right">{formatCurrency(exp.amount)}</td>
+              <td className="px-4 py-3">
+                <Tag
+                  label={exp.status}
+                  color={
+                    exp.status === ExpenseStatus.APPROVED
+                      ? 'green'
+                      : exp.status === ExpenseStatus.REJECTED
+                      ? 'red'
+                      : 'yellow'
+                  }
+                />
+              </td>
+              <td className="px-4 py-3 text-right">
+                {exp.status === ExpenseStatus.REJECTED && (
+                  <Button size="sm" variant="secondary" onClick={() => onEditExpense(exp)}>
+                    Edit &amp; Resubmit
+                  </Button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </Card>
 ));
 
 ExpensesTab.displayName = 'ExpensesTab';
 
 interface ClientsTabProps {
-    clients: Client[];
-    canManageFinances: boolean;
-    onAddClient: () => void;
-    onEditClient: (client: Client) => void;
+  clients: Client[];
+  canManageFinances: boolean;
+  onAddClient: () => void;
+  onEditClient: (client: Client) => void;
 }
 
 const ClientsTab = React.memo(({ clients, canManageFinances, onAddClient, onEditClient }: ClientsTabProps) => (
-    <div>
-        <div className="flex justify-between items-center mb-6">
-            <h2 className="text-2xl font-bold">Clients</h2>
-            {canManageFinances && <Button onClick={onAddClient}>Add Client</Button>}
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {clients.map(client => (
-                <Card key={client.id} className="cursor-pointer hover:shadow-lg" onClick={() => onEditClient(client)}>
-                    <h3 className="text-lg font-semibold">{client.name}</h3>
-                    <p className="text-sm text-muted-foreground">{client.contactEmail}</p>
-                </Card>
-            ))}
-        </div>
+  <div>
+    <div className="flex justify-between items-center mb-6">
+      <h2 className="text-2xl font-bold">Clients</h2>
+      {canManageFinances && <Button onClick={onAddClient}>Add Client</Button>}
     </div>
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {clients.map(client => (
+        <Card key={client.id} className="cursor-pointer hover:shadow-lg" onClick={() => onEditClient(client)}>
+          <h3 className="text-lg font-semibold">{client.name}</h3>
+          <p className="text-sm text-muted-foreground">{client.contactEmail}</p>
+        </Card>
+      ))}
+    </div>
+  </div>
 ));
 
 ClientsTab.displayName = 'ClientsTab';

--- a/components/ProjectDetailView.tsx
+++ b/components/ProjectDetailView.tsx
@@ -1,10 +1,17 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { User, Project, Todo, Document, Role, Permission, TodoStatus, TodoPriority, SafetyIncident, Expense, ExpenseStatus } from '../types';
-
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { User, Project, Todo, Document, Role, Permission, TodoStatus, TodoPriority, SafetyIncident, Expense, ExpenseStatus, ProjectInsight } from '../types';
-
-// FIX: Corrected API import
+import {
+  User,
+  Project,
+  Todo,
+  Document,
+  Permission,
+  TodoStatus,
+  TodoPriority,
+  SafetyIncident,
+  Expense,
+  ExpenseStatus,
+  ProjectInsight,
+} from '../types';
 import { api } from '../services/mockApi';
 import { Card } from './ui/Card';
 import { Button } from './ui/Button';
@@ -19,7 +26,8 @@ import { Tag } from './ui/Tag';
 import { ReminderModal } from './ReminderModal';
 import { WhiteboardView } from './WhiteboardView';
 import { generateProjectHealthSummary } from '../services/ai';
- interface ProjectDetailViewProps {
+
+interface ProjectDetailViewProps {
   project: Project;
   user: User;
   onBack: () => void;
@@ -30,498 +38,712 @@ import { generateProjectHealthSummary } from '../services/ai';
 
 type DetailTab = 'overview' | 'tasks' | 'whiteboard' | 'documents' | 'team' | 'safety' | 'financials';
 
-const formatCurrency = (amount: number) => new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(amount);
+const formatCurrency = (amount: number) =>
+  new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: 'GBP',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
 
 const ProjectHealthSummary: React.FC<{
-    project: Project;
-    insights: ProjectInsight[];
-    onGenerate: () => void;
-    isGenerating: boolean;
-    error?: string | null;
-    isOnline: boolean;
+  project: Project;
+  insights: ProjectInsight[];
+  onGenerate: () => void;
+  isGenerating: boolean;
+  error?: string | null;
+  isOnline: boolean;
 }> = ({ project, insights, onGenerate, isGenerating, error, isOnline }) => {
-    const latestInsight = insights[0] ?? null;
+  const latestInsight = insights[0] ?? null;
 
-    const renderSummary = (summary: string, keyPrefix: string) => (
-        summary
-            .split('\n')
-            .map(line => line.trim())
-            .filter(line => line.length > 0)
-            .map((line, index) => (
-                <p
-                    key={`${keyPrefix}-${index}`}
-                    dangerouslySetInnerHTML={{
-                        __html: line
-                            .replace(/\*\*(.*?)\*\*/g, '<strong class="font-semibold">$1</strong>')
-                            .replace(/^[-•]\s+/, '• '),
-                    }}
-                ></p>
-            ))
-    );
+  const renderSummary = (summary: string, keyPrefix: string) =>
+    summary
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0)
+      .map((line, index) => (
+        <p
+          key={`${keyPrefix}-${index}`}
+          dangerouslySetInnerHTML={{
+            __html: line
+              .replace(/\*\*(.*?)\*\*/g, '<strong class="font-semibold">$1</strong>')
+              .replace(/^[-•]\s+/, '• '),
+          }}
+        />
+      ));
 
-    const metadata = (latestInsight?.metadata ?? {}) as Record<string, unknown>;
-    const totalTasks = typeof metadata.totalTasks === 'number' ? metadata.totalTasks : undefined;
-    const completedTasks = typeof metadata.completedTasks === 'number' ? metadata.completedTasks : undefined;
-    const averageProgress = typeof metadata.averageProgress === 'number' ? metadata.averageProgress : undefined;
-    const budgetUtilisation = typeof metadata.budgetUtilisation === 'number' ? metadata.budgetUtilisation : undefined;
-    const openIncidents = typeof metadata.openIncidents === 'number' ? metadata.openIncidents : undefined;
-    const expenseTotal = typeof metadata.expenseTotal === 'number' ? metadata.expenseTotal : undefined;
-    const isFallback = metadata.isFallback === true;
+  const metadata = (latestInsight?.metadata ?? {}) as Record<string, unknown>;
+  const totalTasks = typeof metadata.totalTasks === 'number' ? metadata.totalTasks : undefined;
+  const completedTasks = typeof metadata.completedTasks === 'number' ? metadata.completedTasks : undefined;
+  const averageProgress = typeof metadata.averageProgress === 'number' ? metadata.averageProgress : undefined;
+  const budgetUtilisation = typeof metadata.budgetUtilisation === 'number' ? metadata.budgetUtilisation : undefined;
+  const openIncidents = typeof metadata.openIncidents === 'number' ? metadata.openIncidents : undefined;
+  const expenseTotal = typeof metadata.expenseTotal === 'number' ? metadata.expenseTotal : undefined;
+  const isFallback = metadata.isFallback === true;
 
-    const tags: { label: string; value: string }[] = [];
-    if (typeof completedTasks === 'number' && typeof totalTasks === 'number' && totalTasks > 0) {
-        tags.push({ label: 'Tasks', value: `${completedTasks}/${totalTasks}` });
-    }
-    if (typeof averageProgress === 'number') {
-        tags.push({ label: 'Avg progress', value: `${Math.round(averageProgress)}%` });
-    }
-    if (typeof budgetUtilisation === 'number') {
-        tags.push({ label: 'Budget used', value: `${Math.round(budgetUtilisation)}%` });
-    }
-    if (typeof openIncidents === 'number') {
-        tags.push({ label: 'Open incidents', value: openIncidents.toString() });
-    }
-    if (typeof expenseTotal === 'number' && expenseTotal > 0) {
-        tags.push({ label: 'Logged expenses', value: formatCurrency(expenseTotal) });
-    }
+  const tags: { label: string; value: string }[] = [];
+  if (typeof completedTasks === 'number' && typeof totalTasks === 'number' && totalTasks > 0) {
+    tags.push({ label: 'Tasks', value: `${completedTasks}/${totalTasks}` });
+  }
+  if (typeof averageProgress === 'number') {
+    tags.push({ label: 'Avg progress', value: `${Math.round(averageProgress)}%` });
+  }
+  if (typeof budgetUtilisation === 'number') {
+    tags.push({ label: 'Budget used', value: `${Math.round(budgetUtilisation)}%` });
+  }
+  if (typeof openIncidents === 'number') {
+    tags.push({ label: 'Open incidents', value: openIncidents.toString() });
+  }
+  if (typeof expenseTotal === 'number' && expenseTotal > 0) {
+    tags.push({ label: 'Logged expenses', value: formatCurrency(expenseTotal) });
+  }
 
-    const buttonLabel = latestInsight ? 'Refresh Summary' : 'Generate Summary';
+  const buttonLabel = latestInsight ? 'Refresh Summary' : 'Generate Summary';
 
-    return (
-        <Card className="bg-muted">
-            <div className="flex justify-between items-center mb-2">
-                 <h3 className="font-semibold text-lg">AI Project Health Summary</h3>
-                 <Button
-                    size="sm"
-                    variant="secondary"
-                    onClick={onGenerate}
-                    isLoading={isGenerating}
-                    disabled={(!isOnline && !isGenerating)}
-                    title={!isOnline ? 'Go online to regenerate the AI summary.' : undefined}
+  return (
+    <Card className="bg-muted">
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="font-semibold text-lg">AI Project Health Summary</h3>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={onGenerate}
+          isLoading={isGenerating}
+          disabled={!isOnline && !isGenerating}
+          title={!isOnline ? 'Go online to regenerate the AI summary.' : undefined}
+        >
+          {buttonLabel}
+        </Button>
+      </div>
+      {error && <p className="text-sm text-destructive mb-2">{error}</p>}
+      {latestInsight ? (
+        <>
+          <div className="text-sm space-y-1 whitespace-pre-wrap">
+            {renderSummary(latestInsight.summary, 'current')}
+          </div>
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-3">
+              {tags.map(tag => (
+                <span
+                  key={tag.label}
+                  className="px-2 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium"
                 >
-                    {buttonLabel}
-                </Button>
+                  {tag.label}: {tag.value}
+                </span>
+              ))}
             </div>
-            {error && <p className="text-sm text-destructive mb-2">{error}</p>}
-            {latestInsight ? (
-                <>
-                    <div className="text-sm space-y-1 whitespace-pre-wrap">
-                        {renderSummary(latestInsight.summary, 'current')}
-                    </div>
-                    {tags.length > 0 && (
-                        <div className="flex flex-wrap gap-2 mt-3">
-                            {tags.map(tag => (
-                                <span key={tag.label} className="px-2 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">
-                                    {tag.label}: {tag.value}
-                                </span>
-                            ))}
-                        </div>
-                    )}
-                    <p className="text-xs text-muted-foreground mt-3">
-                        Last updated {new Date(latestInsight.createdAt).toLocaleString()}
-                        {latestInsight.model ? ` • ${latestInsight.model}` : ''}
-                        {isFallback ? ' • offline summary' : ''}
-                    </p>
-                </>
-            ) : (
-                <p className="text-sm text-muted-foreground">Click "Generate" to get an AI-powered summary of the project's status.</p>
-            )}
-            {insights.length > 1 && (
-                <details className="mt-4 text-sm">
-                    <summary className="cursor-pointer text-muted-foreground">Previous AI snapshots</summary>
-                    <div className="mt-2 space-y-3 max-h-60 overflow-y-auto pr-1">
-                        {insights.slice(1, 5).map(insight => {
-                            const entryMetadata = (insight.metadata ?? {}) as Record<string, unknown>;
-                            const entryFallback = entryMetadata.isFallback === true;
-                            return (
-                                <div key={insight.id} className="border border-border rounded-md p-2 bg-background">
-                                    <p className="text-xs text-muted-foreground">
-                                        {new Date(insight.createdAt).toLocaleString()}
-                                        {insight.model ? ` • ${insight.model}` : ''}
-                                        {entryFallback ? ' • offline summary' : ''}
-                                    </p>
-                                    <div className="text-xs space-y-1 whitespace-pre-wrap mt-1">
-                                        {renderSummary(insight.summary, insight.id)}
-                                    </div>
-                                </div>
-                            );
-                        })}
-                    </div>
-                </details>
-            )}
-        </Card>
-    );
+          )}
+          <p className="text-xs text-muted-foreground mt-3">
+            Last updated {new Date(latestInsight.createdAt).toLocaleString()}
+            {latestInsight.model ? ` • ${latestInsight.model}` : ''}
+            {isFallback ? ' • offline summary' : ''}
+          </p>
+        </>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Click "Generate" to get an AI-powered summary for {project.name}.
+        </p>
+      )}
+      {insights.length > 1 && (
+        <details className="mt-4 text-sm">
+          <summary className="cursor-pointer text-muted-foreground">Previous AI snapshots</summary>
+          <div className="mt-2 space-y-3 max-h-60 overflow-y-auto pr-1">
+            {insights.slice(1, 5).map(insight => {
+              const entryMetadata = (insight.metadata ?? {}) as Record<string, unknown>;
+              const entryFallback = entryMetadata.isFallback === true;
+              return (
+                <div key={insight.id} className="border border-border rounded-md p-2 bg-background">
+                  <p className="text-xs text-muted-foreground">
+                    {new Date(insight.createdAt).toLocaleString()}
+                    {insight.model ? ` • ${insight.model}` : ''}
+                    {entryFallback ? ' • offline summary' : ''}
+                  </p>
+                  <div className="text-xs space-y-1 whitespace-pre-wrap mt-1">
+                    {renderSummary(insight.summary, insight.id)}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </details>
+      )}
+    </Card>
+  );
 };
 
 const TaskItem: React.FC<{
-    task: Todo;
-    allProjectTasks: Todo[];
-    team: User[];
-    canManage: boolean;
-    // FIX: Changed taskId from number | string to just string
-    onUpdate: (taskId: string, updates: Partial<Todo>) => void;
-    onEdit: (task: Todo) => void;
-    onOpenReminder: (task: Todo) => void;
+  task: Todo;
+  allProjectTasks: Todo[];
+  team: User[];
+  canManage: boolean;
+  onUpdate: (taskId: string, updates: Partial<Todo>) => void;
+  onEdit: (task: Todo) => void;
+  onOpenReminder: (task: Todo) => void;
 }> = ({ task, allProjectTasks, team, canManage, onUpdate, onEdit, onOpenReminder }) => {
-    const [progress, setProgress] = useState(task.progress ?? 0);
-    const assignee = useMemo(() => team.find(u => u.id === task.assigneeId), [team, task.assigneeId]);
+  const [progress, setProgress] = useState(task.progress ?? 0);
+  const assignee = useMemo(() => team.find(u => u.id === task.assigneeId), [team, task.assigneeId]);
 
-    useEffect(() => {
-        setProgress(task.progress ?? 0);
-    }, [task.progress]);
+  useEffect(() => {
+    setProgress(task.progress ?? 0);
+  }, [task.progress]);
 
-    const isBlocked = useMemo(() => {
-        if (!task.dependsOn || task.dependsOn.length === 0) return false;
-        return task.dependsOn.some(depId => {
-            const dependency = allProjectTasks.find(t => t.id == depId);
-            return dependency && dependency.status !== TodoStatus.DONE;
-        });
-    }, [task.dependsOn, allProjectTasks]);
+  const isBlocked = useMemo(() => {
+    if (!task.dependsOn || task.dependsOn.length === 0) return false;
+    return task.dependsOn.some(depId => {
+      const dependency = allProjectTasks.find(t => t.id == depId);
+      return dependency && dependency.status !== TodoStatus.DONE;
+    });
+  }, [task.dependsOn, allProjectTasks]);
 
-    const blockerTasks = useMemo(() => {
-        if (!isBlocked || !task.dependsOn) return '';
-        return task.dependsOn
-            .map(depId => allProjectTasks.find(t => t.id == depId))
-            .filter((t): t is Todo => !!t && t.status !== TodoStatus.DONE)
-            .map(t => `#${t.id.toString().substring(0, 5)} - ${t.text}`)
-            .join('\n');
-    }, [isBlocked, task.dependsOn, allProjectTasks]);
+  const blockerTasks = useMemo(() => {
+    if (!isBlocked || !task.dependsOn) return '';
+    return task.dependsOn
+      .map(depId => allProjectTasks.find(t => t.id == depId))
+      .filter((t): t is Todo => !!t && t.status !== TodoStatus.DONE)
+      .map(t => `#${t.id.toString().substring(0, 5)} - ${t.text}`)
+      .join('\n');
+  }, [isBlocked, task.dependsOn, allProjectTasks]);
 
+  const handleProgressChangeCommit = (newProgress: number) => {
+    if (newProgress !== (task.progress ?? 0)) {
+      onUpdate(task.id, { progress: newProgress });
+    }
+  };
 
-    const handleProgressChangeCommit = (newProgress: number) => {
-        if (newProgress !== (task.progress ?? 0)) {
-            onUpdate(task.id, { progress: newProgress });
-        }
-    };
-    
-    const handleToggleComplete = () => {
-        const newProgress = task.status === TodoStatus.DONE ? 0 : 100;
-        setProgress(newProgress); // Optimistic UI update for the slider
-        onUpdate(task.id, { progress: newProgress });
-    };
+  const handleToggleComplete = () => {
+    const newProgress = task.status === TodoStatus.DONE ? 0 : 100;
+    setProgress(newProgress);
+    onUpdate(task.id, { progress: newProgress });
+  };
 
-    return (
-        <div className={`grid grid-cols-1 md:grid-cols-6 items-center gap-x-4 gap-y-2 p-3 rounded-md hover:bg-accent border-b border-border last:border-b-0 ${isBlocked ? 'opacity-60 cursor-not-allowed' : ''}`}>
-            <div className="md:col-span-3 flex items-center gap-3 group">
-                 <input
-                    type="checkbox"
-                    checked={task.status === TodoStatus.DONE}
-                    onChange={handleToggleComplete}
-                    disabled={!canManage || isBlocked}
-                    className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-ring disabled:cursor-not-allowed"
-                />
-                 {isBlocked && (
-                    <div className="text-muted-foreground" title={`Blocked by:\n${blockerTasks}`}>
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                           <path fillRule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clipRule="evenodd" />
-                        </svg>
-                    </div>
-                )}
-                <span className={task.status === TodoStatus.DONE ? 'line-through text-muted-foreground' : ''}>{task.text}</span>
-                {canManage && <ReminderControl todo={task} onClick={() => onOpenReminder(task)} />}
-                {canManage && !isBlocked && (
-                    <button onClick={() => onEdit(task)} className="p-1.5 rounded-full opacity-0 group-hover:opacity-100 hover:bg-black/10 text-muted-foreground hover:text-foreground transition-opacity disabled:opacity-50" aria-label="Edit task" title="Edit Task">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.5L16.732 3.732z" />
-                        </svg>
-                    </button>
-                )}
-            </div>
-             <div className="flex justify-start md:justify-center">
-                {assignee && <Avatar name={`${assignee.firstName} ${assignee.lastName}`} imageUrl={assignee.avatar} className="w-8 h-8 text-xs" />}
-            </div>
-            <div className="md:col-span-2 flex items-center gap-2">
-                 <input
-                    type="range"
-                    min="0" max="100"
-                    value={progress}
-                    onChange={e => setProgress(Number(e.target.value))}
-                    onMouseUp={e => handleProgressChangeCommit(Number(e.currentTarget.value))}
-                    onTouchEnd={e => handleProgressChangeCommit(Number(e.currentTarget.value))}
-                    disabled={!canManage || isBlocked}
-                    className="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
-                />
-                <span className="text-sm font-semibold w-12 text-right">{progress}%</span>
-            </div>
+  const dueDate = task.dueDate ? new Date(task.dueDate) : null;
+  const formattedDueDate = dueDate && !Number.isNaN(dueDate.getTime())
+    ? dueDate.toLocaleDateString()
+    : null;
+
+  return (
+    <div
+      className={`grid grid-cols-1 md:grid-cols-6 items-center gap-x-4 gap-y-2 p-3 rounded-md hover:bg-accent border-b border-border last:border-b-0 ${
+        isBlocked ? 'opacity-60 cursor-not-allowed' : ''
+      }`}
+    >
+      <div className="md:col-span-3 flex items-start gap-3 group">
+        <input
+          type="checkbox"
+          checked={task.status === TodoStatus.DONE}
+          onChange={handleToggleComplete}
+          disabled={!canManage || isBlocked}
+          className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-ring disabled:cursor-not-allowed"
+        />
+        {isBlocked && (
+          <div className="text-muted-foreground" title={`Blocked by:\n${blockerTasks}`}>
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+              <path
+                fillRule="evenodd"
+                d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+        )}
+        <div className="flex flex-col gap-1 flex-1 min-w-0">
+          <span className={task.status === TodoStatus.DONE ? 'line-through text-muted-foreground' : ''}>
+            {task.text}
+          </span>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <PriorityDisplay priority={task.priority ?? TodoPriority.MEDIUM} />
+            {formattedDueDate && <span>Due {formattedDueDate}</span>}
+          </div>
         </div>
-    );
+        {canManage && <ReminderControl todo={task} onClick={() => onOpenReminder(task)} />}
+        {canManage && !isBlocked && (
+          <button
+            onClick={() => onEdit(task)}
+            className="p-1.5 rounded-full opacity-0 group-hover:opacity-100 hover:bg-black/10 text-muted-foreground hover:text-foreground transition-opacity disabled:opacity-50"
+            aria-label="Edit task"
+            title="Edit Task"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.5L16.732 3.732z" />
+            </svg>
+          </button>
+        )}
+      </div>
+      <div className="flex justify-start md:justify-center">
+        {assignee && (
+          <Avatar name={`${assignee.firstName} ${assignee.lastName}`} imageUrl={assignee.avatar} className="w-8 h-8 text-xs" />
+        )}
+      </div>
+      <div className="md:col-span-2 flex items-center gap-2">
+        <input
+          type="range"
+          min="0"
+          max="100"
+          value={progress}
+          onChange={e => setProgress(Number(e.target.value))}
+          onMouseUp={e => handleProgressChangeCommit(Number(e.currentTarget.value))}
+          onTouchEnd={e => handleProgressChangeCommit(Number(e.currentTarget.value))}
+          disabled={!canManage || isBlocked}
+          className="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+        />
+        <span className="text-sm font-semibold w-12 text-right">{progress}%</span>
+      </div>
+    </div>
+  );
 };
 
+export const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
+  project: initialProject,
+  user,
+  onBack,
+  addToast,
+  isOnline,
+  onStartChat,
+}) => {
+  const [project, setProject] = useState(initialProject);
+  const [activeTab, setActiveTab] = useState<DetailTab>('overview');
+  const [tasks, setTasks] = useState<Todo[]>([]);
+  const [documents, setDocuments] = useState<Document[]>([]);
+  const [team, setTeam] = useState<User[]>([]);
+  const [incidents, setIncidents] = useState<SafetyIncident[]>([]);
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [insights, setInsights] = useState<ProjectInsight[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
+  const [taskToEdit, setTaskToEdit] = useState<Todo | null>(null);
+  const [isReminderModalOpen, setIsReminderModalOpen] = useState(false);
+  const [taskForReminder, setTaskForReminder] = useState<Todo | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const [isGeneratingInsight, setIsGeneratingInsight] = useState(false);
+  const [insightError, setInsightError] = useState<string | null>(null);
 
-export const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({ project: initialProject, user, onBack, addToast, isOnline, onStartChat }) => {
-    const [project, setProject] = useState(initialProject);
-    const [activeTab, setActiveTab] = useState<DetailTab>('overview');
-    const [tasks, setTasks] = useState<Todo[]>([]);
-    const [documents, setDocuments] = useState<Document[]>([]);
-    const [team, setTeam] = useState<User[]>([]);
-    const [incidents, setIncidents] = useState<SafetyIncident[]>([]);
-    const [expenses, setExpenses] = useState<Expense[]>([]);
-    const [insights, setInsights] = useState<ProjectInsight[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-    const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
-    const [taskToEdit, setTaskToEdit] = useState<Todo | null>(null);
-    const [isReminderModalOpen, setIsReminderModalOpen] = useState(false);
-    const [taskForReminder, setTaskForReminder] = useState<Todo | null>(null);
- codex/add-abort-feature-to-fetchdata
-    const abortControllerRef = useRef<AbortController | null>(null);
+  const fetchData = useCallback(async () => {
+    const controller = new AbortController();
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = controller;
 
-    const [isGeneratingInsight, setIsGeneratingInsight] = useState(false);
-    const [insightError, setInsightError] = useState<string | null>(null);
- main
+    setLoading(true);
+    try {
+      if (!user.companyId) return;
+      const [taskData, docData, teamData, allIncidents, allExpenses, insightData] = await Promise.all([
+        api.getTodosByProjectIds([project.id], { signal: controller.signal }),
+        api.getDocumentsByProject(project.id, { signal: controller.signal }),
+        api.getUsersByProject(project.id, { signal: controller.signal }),
+        api.getSafetyIncidentsByCompany(user.companyId, { signal: controller.signal }),
+        api.getExpensesByCompany(user.companyId, { signal: controller.signal }),
+        api.getProjectInsights(project.id, { signal: controller.signal }),
+      ]);
+      if (controller.signal.aborted) return;
 
-    const fetchData = useCallback(async () => {
-        const controller = new AbortController();
-        abortControllerRef.current?.abort();
-        abortControllerRef.current = controller;
+      setTasks(taskData.sort((a, b) => (a.progress ?? 0) - (b.progress ?? 0)));
+      if (controller.signal.aborted) return;
+      setDocuments(docData as Document[]);
+      if (controller.signal.aborted) return;
+      setTeam(teamData);
+      if (controller.signal.aborted) return;
+      setIncidents(allIncidents.filter(i => i.projectId == project.id));
+      if (controller.signal.aborted) return;
+      setExpenses(allExpenses.filter(e => e.projectId == project.id));
+      if (controller.signal.aborted) return;
+      setInsights(insightData);
+      setInsightError(null);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      addToast('Failed to load project details.', 'error');
+    } finally {
+      if (controller.signal.aborted) return;
+      setLoading(false);
+    }
+  }, [project.id, user.companyId, addToast]);
 
-        setLoading(true);
-        try {
-            if (!user.companyId) return;
- codex/add-abort-feature-to-fetchdata
-            const [taskData, docData, teamData, allIncidents, allExpenses] = await Promise.all([
-                api.getTodosByProjectIds([project.id], { signal: controller.signal }),
-                api.getDocumentsByProject(project.id, { signal: controller.signal }),
-                api.getUsersByProject(project.id, { signal: controller.signal }),
-                api.getSafetyIncidentsByCompany(user.companyId, { signal: controller.signal }),
-                api.getExpensesByCompany(user.companyId, { signal: controller.signal }),
-
-            const [taskData, docData, teamData, allIncidents, allExpenses, insightData] = await Promise.all([
-                api.getTodosByProjectIds([project.id]),
-                api.getDocumentsByProject(project.id),
-                api.getUsersByProject(project.id),
-                api.getSafetyIncidentsByCompany(user.companyId),
-                api.getExpensesByCompany(user.companyId),
-                api.getProjectInsights(project.id),
-            ]);
-            if (controller.signal.aborted) return;
-            setTasks(taskData.sort((a,b) => (a.progress ?? 0) - (b.progress ?? 0)));
-            if (controller.signal.aborted) return;
-            setDocuments(docData as any);
-            if (controller.signal.aborted) return;
-            setTeam(teamData);
-            if (controller.signal.aborted) return;
-            setIncidents(allIncidents.filter(i => i.projectId == project.id));
-            if (controller.signal.aborted) return;
-            setExpenses(allExpenses.filter(e => e.projectId == project.id));
-            setInsights(insightData);
-            setInsightError(null);
-        } catch (error) {
-            if (controller.signal.aborted) return;
-            addToast("Failed to load project details.", "error");
-        } finally {
-            if (controller.signal.aborted) return;
-            setLoading(false);
-        }
-    }, [project.id, user.companyId, addToast]);
-
-    useEffect(() => {
-        fetchData();
-        return () => {
-            abortControllerRef.current?.abort();
-        };
-    }, [fetchData]);
-    
-    useEffect(() => {
-        setProject(initialProject);
-    }, [initialProject]);
-
-    const handleGenerateInsight = useCallback(async () => {
-        if (isGeneratingInsight) return;
-        setIsGeneratingInsight(true);
-        setInsightError(null);
-        try {
-            const result = await generateProjectHealthSummary({
-                project,
-                tasks,
-                incidents,
-                expenses,
-            });
-
-            const newInsight = await api.createProjectInsight({
-                projectId: project.id,
-                summary: result.summary,
-                type: 'HEALTH_SUMMARY',
-                metadata: result.metadata,
-                model: result.model,
-            }, user.id);
-
-            setInsights(prev => [newInsight, ...prev]);
-            addToast(result.isFallback ? 'Generated offline project summary.' : 'AI project summary updated.', 'success');
-        } catch (error) {
-            console.error('Failed to generate project insight', error);
-            const message = error instanceof Error ? error.message : 'Failed to generate AI summary.';
-            setInsightError(message);
-            addToast('Failed to generate AI summary.', 'error');
-        } finally {
-            setIsGeneratingInsight(false);
-        }
-    }, [isGeneratingInsight, project, tasks, incidents, expenses, user.id, addToast]);
-
-    // FIX: Changed taskId from number | string to string to match the API.
-    const handleTaskUpdate = async (taskId: string, updates: Partial<Todo>) => {
-        const originalTasks = [...tasks];
-        setTasks(prevTasks => prevTasks.map(t => t.id === taskId ? { ...t, ...updates } : t));
-        try {
-            await api.updateTodo(taskId, updates, user.id);
-            // After successful API call, refresh all data to get consistent dependency statuses
-            fetchData();
-            addToast("Task updated.", "success");
-        } catch (e) {
-            addToast("Failed to update task.", "error");
-            setTasks(originalTasks);
-        }
+  useEffect(() => {
+    fetchData();
+    return () => {
+      abortControllerRef.current?.abort();
     };
-    
-    const handleOpenTaskModal = (task: Todo | null) => {
-        setTaskToEdit(task);
-        setIsTaskModalOpen(true);
-    };
+  }, [fetchData]);
 
-    const handleOpenReminderModal = (task: Todo) => {
-        setTaskForReminder(task);
-        setIsReminderModalOpen(true);
-    };
+  useEffect(() => {
+    setProject(initialProject);
+  }, [initialProject]);
 
-    const handleTaskModalSuccess = () => {
-        // Just refresh all data to ensure dependency graph is correct
-        fetchData();
-    };
+  const handleGenerateInsight = useCallback(async () => {
+    if (isGeneratingInsight) return;
+    setIsGeneratingInsight(true);
+    setInsightError(null);
+    try {
+      const result = await generateProjectHealthSummary({
+        project,
+        tasks,
+        incidents,
+        expenses,
+      });
 
-    const handleProjectUpdate = (updatedProject: Project) => setProject(updatedProject);
+      const newInsight = await api.createProjectInsight(
+        {
+          projectId: project.id,
+          summary: result.summary,
+          type: 'HEALTH_SUMMARY',
+          metadata: result.metadata,
+          model: result.model,
+        },
+        user.id,
+      );
 
-    const canManageTasks = hasPermission(user, Permission.MANAGE_ALL_TASKS);
-    
-    // --- Render Methods for Tabs ---
+      setInsights(prev => [newInsight, ...prev]);
+      addToast(result.isFallback ? 'Generated offline project summary.' : 'AI project summary updated.', 'success');
+    } catch (error) {
+      console.error('Failed to generate project insight', error);
+      const message = error instanceof Error ? error.message : 'Failed to generate AI summary.';
+      setInsightError(message);
+      addToast('Failed to generate AI summary.', 'error');
+    } finally {
+      setIsGeneratingInsight(false);
+    }
+  }, [isGeneratingInsight, project, tasks, incidents, expenses, user.id, addToast]);
 
-    const renderTasks = () => (
-        <Card>
-            <div className="flex justify-between items-center mb-4">
-                <h3 className="font-semibold text-lg">Tasks</h3>
-                {canManageTasks && <Button onClick={() => handleOpenTaskModal(null)}>Add Task</Button>}
-            </div>
-            {tasks.length > 0 ? (
-                <div className="space-y-1">{tasks.map(task => <TaskItem key={task.id} task={task} allProjectTasks={tasks} team={team} canManage={canManageTasks} onUpdate={handleTaskUpdate} onEdit={handleOpenTaskModal} onOpenReminder={handleOpenReminderModal} />)}</div>
-            ) : <p className="text-muted-foreground text-center py-4">No tasks for this project yet.</p>}
-        </Card>
-    );
-    
-    const renderDocuments = () => (
-        <Card>
-            <h3 className="font-semibold text-lg mb-4">Documents</h3>
-            {documents.length > 0 ? (
-                <ul className="divide-y border-border">{documents.map(doc => (<li key={doc.id} className="py-3 flex justify-between items-center"><div><p className="font-medium">{doc.name}</p><p className="text-sm text-muted-foreground">{doc.category} - v{doc.version}</p></div><Button variant="secondary" size="sm">Download</Button></li>))}</ul>
-            ) : <p className="text-muted-foreground text-center py-4">No documents uploaded for this project.</p>}
-        </Card>
-    );
-    
-    const renderTeam = () => (
-         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-            {team.map(member => (<Card key={member.id} className="text-center"><Avatar name={`${member.firstName} ${member.lastName}`} imageUrl={member.avatar} className="w-20 h-20 mx-auto mb-4" /><h4 className="font-semibold">{`${member.firstName} ${member.lastName}`}</h4><p className="text-sm text-muted-foreground">{member.role}</p>{user.id !== member.id && hasPermission(user, Permission.SEND_DIRECT_MESSAGE) && (<Button variant="ghost" size="sm" className="mt-2" onClick={() => onStartChat(member)}>Message</Button>)}</Card>))}
-        </div>
-    );
-    
-    const renderSafety = () => (
-         <Card>
-            <h3 className="font-semibold text-lg mb-4">Safety Incidents</h3>
-            {incidents.length > 0 ? (
-                 <div className="overflow-x-auto"><table className="min-w-full divide-y divide-border"><thead className="bg-muted"><tr><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Description</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Severity</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Status</th><th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Date</th></tr></thead><tbody className="bg-card divide-y divide-border">{incidents.map(incident => (<tr key={incident.id}><td className="px-4 py-3 text-sm max-w-md truncate" title={incident.description}>{incident.description}</td><td className="px-4 py-3"><IncidentSeverityBadge severity={incident.severity} /></td><td className="px-4 py-3"><IncidentStatusBadge status={incident.status} /></td><td className="px-4 py-3 text-sm">{new Date(incident.timestamp).toLocaleDateString()}</td></tr>))}</tbody></table></div>
-            ) : <p className="text-muted-foreground text-center py-4">No safety incidents reported for this project.</p>}
-        </Card>
-    );
+  const handleTaskUpdate = async (taskId: string, updates: Partial<Todo>) => {
+    const originalTasks = [...tasks];
+    setTasks(prevTasks => prevTasks.map(t => (t.id === taskId ? { ...t, ...updates } : t)));
+    try {
+      await api.updateTodo(taskId, updates, user.id);
+      fetchData();
+      addToast('Task updated.', 'success');
+    } catch (error) {
+      addToast('Failed to update task.', 'error');
+      setTasks(originalTasks);
+    }
+  };
 
-    const renderFinancials = () => {
-        const totalInvoiced = 0; // This would need to be calculated from invoice data
-        const totalExpenses = expenses.reduce((acc, exp) => acc + exp.amount, 0);
-        const profitability = project.budget > 0 ? ((project.budget - (project.actualCost + totalExpenses)) / project.budget) * 100 : 0;
+  const handleOpenTaskModal = (task: Todo | null) => {
+    setTaskToEdit(task);
+    setIsTaskModalOpen(true);
+  };
 
-        return (
-            <div className="space-y-6">
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    <Card><p className="text-sm text-muted-foreground">Budget vs Actual</p><p className="text-2xl font-bold">{formatCurrency(project.actualCost)} / {formatCurrency(project.budget)}</p></Card>
-                    <Card><p className="text-sm text-muted-foreground">Total Invoiced</p><p className="text-2xl font-bold">{formatCurrency(totalInvoiced)}</p></Card>
-                    <Card><p className="text-sm text-muted-foreground">Profitability</p><p className={`text-2xl font-bold ${profitability < 0 ? 'text-red-500' : 'text-green-500'}`}>{profitability.toFixed(1)}%</p></Card>
-                </div>
-                <Card>
-                    <h3 className="font-semibold text-lg mb-4">Expenses for this Project</h3>
-                    {expenses.length > 0 ? (
-                        expenses.map(exp => (
-                            <div key={exp.id} className="p-2 border-b flex justify-between items-center">
-                                <div><p>{new Date(exp.submittedAt).toLocaleDateString()} - {exp.description}</p><p className="text-sm text-muted-foreground">{exp.category}</p></div>
-                                {/* FIX: Corrected status comparison to use enum values. */}
-                                <div className="text-right"><p className="font-semibold">{formatCurrency(exp.amount)}</p><Tag label={exp.status} color={exp.status === ExpenseStatus.APPROVED ? 'green' : exp.status === ExpenseStatus.REJECTED ? 'red' : 'yellow'} /></div>
-                            </div>
-                        ))
-                    ) : <p className="text-muted-foreground text-center py-4">No expenses logged for this project.</p>}
-                </Card>
-            </div>
-        );
-    };
+  const handleOpenReminderModal = (task: Todo) => {
+    setTaskForReminder(task);
+    setIsReminderModalOpen(true);
+  };
 
-    const renderOverview = () => (
-        <div className="space-y-6">
-            <ProjectHealthSummary
-                project={project}
-                insights={insights}
-                onGenerate={handleGenerateInsight}
-                isGenerating={isGeneratingInsight}
-                error={insightError ?? undefined}
-                isOnline={isOnline}
+  const handleTaskModalSuccess = () => {
+    fetchData();
+  };
+
+  const handleProjectUpdate = (updatedProject: Project) => setProject(updatedProject);
+
+  const canManageTasks = hasPermission(user, Permission.MANAGE_ALL_TASKS);
+
+  const renderTasks = () => (
+    <Card>
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="font-semibold text-lg">Tasks</h3>
+        {canManageTasks && <Button onClick={() => handleOpenTaskModal(null)}>Add Task</Button>}
+      </div>
+      {tasks.length > 0 ? (
+        <div className="space-y-1">
+          {tasks.map(task => (
+            <TaskItem
+              key={task.id}
+              task={task}
+              allProjectTasks={tasks}
+              team={team}
+              canManage={canManageTasks}
+              onUpdate={handleTaskUpdate}
+              onEdit={handleOpenTaskModal}
+              onOpenReminder={handleOpenReminderModal}
             />
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <Card><h3 className="font-semibold mb-2">Budget</h3><p className="text-3xl font-bold">{formatCurrency(project.actualCost)}</p><p className="text-sm text-muted-foreground">of {formatCurrency(project.budget)} used</p><div className="w-full bg-muted rounded-full h-2.5 mt-2"><div className="bg-green-600 h-2.5 rounded-full" style={{ width: `${(project.actualCost / project.budget) * 100}%` }}></div></div></Card>
-                <Card><h3 className="font-semibold mb-2">Team Members</h3><div className="flex -space-x-2">{team.map(member => <Avatar key={member.id} name={`${member.firstName} ${member.lastName}`} imageUrl={member.avatar} className="w-10 h-10 border-2 border-card" />)}</div></Card>
-                <Card><h3 className="font-semibold mb-2">Key Info</h3><p className="text-sm">Start: {new Date(project.startDate).toLocaleDateString()}</p>{project.geofenceRadius && <p className="text-sm">Geofence: {project.geofenceRadius}m</p>}</Card>
-            </div>
+          ))}
         </div>
-    );
-    
-    const renderContent = () => {
-        if(loading) return <Card>Loading project details...</Card>
-        switch(activeTab) {
-            case 'overview': return renderOverview();
-            case 'tasks': return renderTasks();
-            case 'whiteboard': return <WhiteboardView project={project} user={user} addToast={addToast} />;
-            case 'documents': return renderDocuments();
-            case 'team': return renderTeam();
-            case 'safety': return renderSafety();
-            case 'financials': return renderFinancials();
-            default: return renderOverview();
-        }
-    };
+      ) : (
+        <p className="text-muted-foreground text-center py-4">No tasks for this project yet.</p>
+      )}
+    </Card>
+  );
+
+  const renderDocuments = () => (
+    <Card>
+      <h3 className="font-semibold text-lg mb-4">Documents</h3>
+      {documents.length > 0 ? (
+        <ul className="divide-y border-border">
+          {documents.map(doc => (
+            <li key={doc.id} className="py-3 flex justify-between items-center">
+              <div>
+                <p className="font-medium">{doc.name}</p>
+                <p className="text-sm text-muted-foreground">
+                  {doc.category} - v{doc.version}
+                </p>
+              </div>
+              <Button variant="secondary" size="sm">
+                Download
+              </Button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-muted-foreground text-center py-4">No documents uploaded for this project.</p>
+      )}
+    </Card>
+  );
+
+  const renderTeam = () => (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      {team.map(member => (
+        <Card key={member.id} className="text-center">
+          <Avatar
+            name={`${member.firstName} ${member.lastName}`}
+            imageUrl={member.avatar}
+            className="w-20 h-20 mx-auto mb-4"
+          />
+          <h4 className="font-semibold">{`${member.firstName} ${member.lastName}`}</h4>
+          <p className="text-sm text-muted-foreground">{member.role}</p>
+          {user.id !== member.id && hasPermission(user, Permission.SEND_DIRECT_MESSAGE) && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mt-2"
+              onClick={() => onStartChat(member)}
+            >
+              Message
+            </Button>
+          )}
+        </Card>
+      ))}
+    </div>
+  );
+
+  const renderSafety = () => (
+    <Card>
+      <h3 className="font-semibold text-lg mb-4">Safety Incidents</h3>
+      {incidents.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-border">
+            <thead className="bg-muted">
+              <tr>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Description</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Severity</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Status</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase">Date</th>
+              </tr>
+            </thead>
+            <tbody className="bg-card divide-y divide-border">
+              {incidents.map(incident => (
+                <tr key={incident.id}>
+                  <td className="px-4 py-3 text-sm max-w-md truncate" title={incident.description}>
+                    {incident.description}
+                  </td>
+                  <td className="px-4 py-3">
+                    <IncidentSeverityBadge severity={incident.severity} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <IncidentStatusBadge status={incident.status} />
+                  </td>
+                  <td className="px-4 py-3 text-sm">{new Date(incident.timestamp).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-center py-4">No safety incidents reported for this project.</p>
+      )}
+    </Card>
+  );
+
+  const renderFinancials = () => {
+    const totalInvoiced = 0; // Placeholder until invoice linkage is implemented
+    const totalExpenses = expenses.reduce((acc, exp) => acc + exp.amount, 0);
+    const profitability =
+      project.budget > 0 ? ((project.budget - (project.actualCost + totalExpenses)) / project.budget) * 100 : 0;
 
     return (
-        <div className="space-y-6">
-            {isEditModalOpen && <ProjectModal user={user} onClose={() => setIsEditModalOpen(false)} onSuccess={handleProjectUpdate} addToast={addToast} projectToEdit={project}/>}
-            {isTaskModalOpen && <TaskModal user={user} projects={[project]} users={team} onClose={() => setIsTaskModalOpen(false)} onSuccess={handleTaskModalSuccess} addToast={addToast} taskToEdit={taskToEdit} allProjectTasks={tasks}/>}
-            {isReminderModalOpen && taskForReminder && (
-                <ReminderModal
-                    todo={taskForReminder}
-                    user={user}
-                    onClose={() => setIsReminderModalOpen(false)}
-                    onSuccess={fetchData}
-                    addToast={addToast}
-                />
-            )}
-            
-            <button onClick={onBack} className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground">&larr; Back to all projects</button>
-            
-            <div className="flex justify-between items-start">
-                <div><h1 className="text-4xl font-bold text-foreground">{project.name}</h1><p className="text-muted-foreground">{project.location.address}</p></div>
-                {hasPermission(user, Permission.MANAGE_PROJECT_DETAILS) && <Button onClick={() => setIsEditModalOpen(true)}>Edit Project</Button>}
-            </div>
-            
-             <div className="border-b border-border">
-                <nav className="-mb-px flex space-x-6 overflow-x-auto">
-                    {(['overview', 'tasks', 'whiteboard', 'documents', 'team', 'safety', 'financials'] as DetailTab[]).map(tab => (
-                         <button key={tab} onClick={() => setActiveTab(tab)} className={`capitalize whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm transition-colors ${activeTab === tab ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'}`}>
-                            {tab}
-                        </button>
-                    ))}
-                </nav>
-            </div>
-
-            {renderContent()}
+      <div className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <Card>
+            <p className="text-sm text-muted-foreground">Budget vs Actual</p>
+            <p className="text-2xl font-bold">
+              {formatCurrency(project.actualCost)} / {formatCurrency(project.budget)}
+            </p>
+          </Card>
+          <Card>
+            <p className="text-sm text-muted-foreground">Total Invoiced</p>
+            <p className="text-2xl font-bold">{formatCurrency(totalInvoiced)}</p>
+          </Card>
+          <Card>
+            <p className="text-sm text-muted-foreground">Profitability</p>
+            <p className={`text-2xl font-bold ${profitability < 0 ? 'text-red-500' : 'text-green-500'}`}>
+              {profitability.toFixed(1)}%
+            </p>
+          </Card>
         </div>
+        <Card>
+          <h3 className="font-semibold text-lg mb-4">Expenses for this Project</h3>
+          {expenses.length > 0 ? (
+            expenses.map(exp => (
+              <div key={exp.id} className="p-2 border-b flex justify-between items-center">
+                <div>
+                  <p>
+                    {new Date(exp.submittedAt).toLocaleDateString()} - {exp.description}
+                  </p>
+                  <p className="text-sm text-muted-foreground">{exp.category}</p>
+                </div>
+                <div className="text-right">
+                  <p className="font-semibold">{formatCurrency(exp.amount)}</p>
+                  <Tag
+                    label={exp.status}
+                    color={
+                      exp.status === ExpenseStatus.APPROVED
+                        ? 'green'
+                        : exp.status === ExpenseStatus.REJECTED
+                        ? 'red'
+                        : 'yellow'
+                    }
+                  />
+                </div>
+              </div>
+            ))
+          ) : (
+            <p className="text-muted-foreground text-center py-4">No expenses logged for this project.</p>
+          )}
+        </Card>
+      </div>
     );
+  };
+
+  const renderOverview = () => (
+    <div className="space-y-6">
+      <ProjectHealthSummary
+        project={project}
+        insights={insights}
+        onGenerate={handleGenerateInsight}
+        isGenerating={isGeneratingInsight}
+        error={insightError ?? undefined}
+        isOnline={isOnline}
+      />
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Card>
+          <h3 className="font-semibold mb-2">Budget</h3>
+          <p className="text-3xl font-bold">{formatCurrency(project.actualCost)}</p>
+          <p className="text-sm text-muted-foreground">of {formatCurrency(project.budget)} used</p>
+          <div className="w-full bg-muted rounded-full h-2.5 mt-2">
+            <div
+              className="bg-green-600 h-2.5 rounded-full"
+              style={{ width: `${project.budget > 0 ? (project.actualCost / project.budget) * 100 : 0}%` }}
+            />
+          </div>
+        </Card>
+        <Card>
+          <h3 className="font-semibold mb-2">Team Members</h3>
+          <div className="flex -space-x-2">
+            {team.map(member => (
+              <Avatar
+                key={member.id}
+                name={`${member.firstName} ${member.lastName}`}
+                imageUrl={member.avatar}
+                className="w-10 h-10 border-2 border-card"
+              />
+            ))}
+          </div>
+        </Card>
+        <Card>
+          <h3 className="font-semibold mb-2">Key Info</h3>
+          <p className="text-sm">Start: {new Date(project.startDate).toLocaleDateString()}</p>
+          <p className="text-sm">Due: {new Date(project.endDate).toLocaleDateString()}</p>
+          {project.geofenceRadius && <p className="text-sm">Geofence: {project.geofenceRadius}m</p>}
+        </Card>
+      </div>
+    </div>
+  );
+
+  const renderContent = () => {
+    if (loading) return <Card>Loading project details...</Card>;
+    switch (activeTab) {
+      case 'overview':
+        return renderOverview();
+      case 'tasks':
+        return renderTasks();
+      case 'whiteboard':
+        return <WhiteboardView project={project} user={user} addToast={addToast} />;
+      case 'documents':
+        return renderDocuments();
+      case 'team':
+        return renderTeam();
+      case 'safety':
+        return renderSafety();
+      case 'financials':
+        return renderFinancials();
+      default:
+        return renderOverview();
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {isEditModalOpen && (
+        <ProjectModal
+          user={user}
+          onClose={() => setIsEditModalOpen(false)}
+          onSuccess={handleProjectUpdate}
+          addToast={addToast}
+          projectToEdit={project}
+        />
+      )}
+      {isTaskModalOpen && (
+        <TaskModal
+          user={user}
+          projects={[project]}
+          users={team}
+          onClose={() => setIsTaskModalOpen(false)}
+          onSuccess={handleTaskModalSuccess}
+          addToast={addToast}
+          taskToEdit={taskToEdit}
+          allProjectTasks={tasks}
+        />
+      )}
+      {isReminderModalOpen && taskForReminder && (
+        <ReminderModal
+          todo={taskForReminder}
+          user={user}
+          onClose={() => setIsReminderModalOpen(false)}
+          onSuccess={fetchData}
+          addToast={addToast}
+        />
+      )}
+
+      <button
+        onClick={onBack}
+        className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+      >
+        &larr; Back to all projects
+      </button>
+
+      <div className="flex justify-between items-start">
+        <div>
+          <h1 className="text-4xl font-bold text-foreground">{project.name}</h1>
+          <p className="text-muted-foreground">{project.location.address}</p>
+        </div>
+        {hasPermission(user, Permission.MANAGE_PROJECT_DETAILS) && (
+          <Button onClick={() => setIsEditModalOpen(true)}>Edit Project</Button>
+        )}
+      </div>
+
+      <div className="border-b border-border">
+        <nav className="-mb-px flex space-x-6 overflow-x-auto">
+          {(['overview', 'tasks', 'whiteboard', 'documents', 'team', 'safety', 'financials'] as DetailTab[]).map(tab => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`capitalize whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm transition-colors ${
+                activeTab === tab ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {renderContent()}
+    </div>
+  );
 };

--- a/components/ProjectsView.tsx
+++ b/components/ProjectsView.tsx
@@ -1,12 +1,5 @@
-// full contents of components/ProjectsView.tsx
-
- codex/add-abort-feature-to-fetchdata
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { User, Project, Permission } from '../types';
-
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { User, Project, Permission, ProjectStatus } from '../types';
- main
 import { api } from '../services/mockApi';
 import { hasPermission } from '../services/auth';
 import { Card } from './ui/Card';
@@ -22,207 +15,218 @@ interface ProjectsViewProps {
 }
 
 const statusAccent: Record<ProjectStatus, { bg: string; text: string }> = {
-    PLANNING: { bg: 'bg-amber-500/10', text: 'text-amber-700 dark:text-amber-300' },
-    ACTIVE: { bg: 'bg-emerald-500/10', text: 'text-emerald-700 dark:text-emerald-300' },
-    ON_HOLD: { bg: 'bg-amber-500/10', text: 'text-amber-700 dark:text-amber-300' },
-    COMPLETED: { bg: 'bg-primary/10', text: 'text-primary dark:text-primary-200' },
-    CANCELLED: { bg: 'bg-slate-500/10', text: 'text-slate-500 dark:text-slate-300' },
+  PLANNING: { bg: 'bg-amber-500/10', text: 'text-amber-700 dark:text-amber-300' },
+  ACTIVE: { bg: 'bg-emerald-500/10', text: 'text-emerald-700 dark:text-emerald-300' },
+  ON_HOLD: { bg: 'bg-amber-500/10', text: 'text-amber-700 dark:text-amber-300' },
+  COMPLETED: { bg: 'bg-primary/10', text: 'text-primary dark:text-primary-200' },
+  CANCELLED: { bg: 'bg-slate-500/10', text: 'text-slate-500 dark:text-slate-300' },
 };
 
 const formatCurrency = (value: number): string =>
-    new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', notation: 'compact', compactDisplay: 'short' }).format(value || 0);
+  new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: 'GBP',
+    notation: 'compact',
+    compactDisplay: 'short',
+  }).format(value || 0);
 
-const ProjectCard: React.FC<{ project: Project; onSelect: () => void; }> = ({ project, onSelect }) => {
-    const budgetUtilization = project.budget > 0 ? (project.actualCost / project.budget) * 100 : 0;
-    const statusStyles = statusAccent[project.status] ?? statusAccent.PLANNING;
-    const overBudget = budgetUtilization > 100;
+const ProjectCard: React.FC<{ project: Project; onSelect: () => void }> = ({ project, onSelect }) => {
+  const budgetUtilization = project.budget > 0 ? (project.actualCost / project.budget) * 100 : 0;
+  const statusStyles = statusAccent[project.status] ?? statusAccent.PLANNING;
+  const overBudget = budgetUtilization > 100;
 
-    return (
-        <Card onClick={onSelect} className="group cursor-pointer space-y-4 transition-all hover:-translate-y-1 hover:shadow-lg animate-card-enter">
-            <div className="relative h-40 overflow-hidden rounded-lg bg-muted">
-                {project.imageUrl ? (
-                    <img src={project.imageUrl} alt={project.name} className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" />
-                ) : (
-                    <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">No cover image</div>
-                )}
-                <div className="absolute left-3 top-3 flex items-center gap-2 text-xs font-semibold">
-                    <Tag label={project.projectType} color="blue" />
-                    <Tag label={project.workClassification} color="gray" />
-                </div>
-            </div>
-            <div className="space-y-2">
-                <div className="flex items-start justify-between gap-3">
-                    <div>
-                        <h3 className="text-lg font-semibold text-foreground line-clamp-2">{project.name}</h3>
-                        <p className="text-xs text-muted-foreground">{project.location.address}</p>
-                    </div>
-                    <span className={`rounded-full px-3 py-1 text-xs font-semibold ${statusStyles.bg} ${statusStyles.text}`}>
-                        {project.status.replace(/_/g, ' ')}
-                    </span>
-                </div>
-                <div className="flex items-center justify-between text-sm text-muted-foreground">
-                    <span>Budget {formatCurrency(project.budget)}</span>
-                    <span className={overBudget ? 'font-semibold text-rose-500 dark:text-rose-300' : 'text-emerald-600 dark:text-emerald-300'}>
-                        {overBudget ? `+${Math.round(budgetUtilization - 100)}%` : `${Math.round(budgetUtilization)}% used`}
-                    </span>
-                </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-                    <div
-                        className={`${overBudget ? 'bg-rose-500' : 'bg-emerald-500'} h-full rounded-full transition-all`}
-                        style={{ width: `${Math.min(100, Math.max(0, budgetUtilization))}%` }}
-                    />
-                </div>
-                <div className="flex items-center justify-between text-xs text-muted-foreground">
-                    <span>Start {new Date(project.startDate).toLocaleDateString()}</span>
-                    <span>Due {new Date(project.endDate).toLocaleDateString()}</span>
-                </div>
-            </div>
-        </Card>
-    );
+  return (
+    <Card onClick={onSelect} className="group cursor-pointer space-y-4 transition-all hover:-translate-y-1 hover:shadow-lg animate-card-enter">
+      <div className="relative h-40 overflow-hidden rounded-lg bg-muted">
+        {project.imageUrl ? (
+          <img
+            src={project.imageUrl}
+            alt={project.name}
+            className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+            No cover image
+          </div>
+        )}
+        <div className="absolute left-3 top-3 flex items-center gap-2 text-xs font-semibold">
+          <Tag label={project.projectType} color="blue" />
+          <Tag label={project.workClassification} color="gray" />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-lg font-semibold text-foreground line-clamp-2">{project.name}</h3>
+            <p className="text-xs text-muted-foreground">{project.location.address}</p>
+          </div>
+          <span className={`rounded-full px-3 py-1 text-xs font-semibold ${statusStyles.bg} ${statusStyles.text}`}>
+            {project.status.replace(/_/g, ' ')}
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>Budget {formatCurrency(project.budget)}</span>
+          <span className={overBudget ? 'font-semibold text-rose-500 dark:text-rose-300' : 'text-emerald-600 dark:text-emerald-300'}>
+            {overBudget ? `+${Math.round(budgetUtilization - 100)}%` : `${Math.round(budgetUtilization)}% used`}
+          </span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className={`${overBudget ? 'bg-rose-500' : 'bg-emerald-500'} h-full rounded-full transition-all`}
+            style={{ width: `${Math.min(100, Math.max(0, budgetUtilization))}%` }}
+          />
+        </div>
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>Start {new Date(project.startDate).toLocaleDateString()}</span>
+          <span>Due {new Date(project.endDate).toLocaleDateString()}</span>
+        </div>
+      </div>
+    </Card>
+  );
 };
 
 const PROJECT_FILTERS: Array<{ label: string; value: 'ALL' | ProjectStatus }> = [
-    { label: 'All', value: 'ALL' },
-    { label: 'Active', value: 'ACTIVE' },
-    { label: 'Planning', value: 'PLANNING' },
-    { label: 'On Hold', value: 'ON_HOLD' },
-    { label: 'Completed', value: 'COMPLETED' },
-    { label: 'Cancelled', value: 'CANCELLED' },
+  { label: 'All', value: 'ALL' },
+  { label: 'Active', value: 'ACTIVE' },
+  { label: 'Planning', value: 'PLANNING' },
+  { label: 'On Hold', value: 'ON_HOLD' },
+  { label: 'Completed', value: 'COMPLETED' },
+  { label: 'Cancelled', value: 'CANCELLED' },
 ];
 
 export const ProjectsView: React.FC<ProjectsViewProps> = ({ user, addToast, onSelectProject }) => {
-    const [projects, setProjects] = useState<Project[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [filter, setFilter] = useState<'ALL' | ProjectStatus>('ALL');
-    const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-    const abortControllerRef = useRef<AbortController | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<'ALL' | ProjectStatus>('ALL');
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
-    const canCreate = hasPermission(user, Permission.CREATE_PROJECT);
+  const canCreate = hasPermission(user, Permission.CREATE_PROJECT);
 
-    const fetchData = useCallback(async () => {
-        const controller = new AbortController();
-        abortControllerRef.current?.abort();
-        abortControllerRef.current = controller;
+  const fetchData = useCallback(async () => {
+    const controller = new AbortController();
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = controller;
 
-        setLoading(true);
-        try {
-            if (!user.companyId) return;
-            let projectsPromise: Promise<Project[]>;
-            if (hasPermission(user, Permission.VIEW_ALL_PROJECTS)) {
-                projectsPromise = api.getProjectsByCompany(user.companyId, { signal: controller.signal });
-            } else {
-                projectsPromise = api.getProjectsByUser(user.id, { signal: controller.signal });
-            }
-            const fetchedProjects = await projectsPromise;
-            if (controller.signal.aborted) return;
-            setProjects(fetchedProjects);
-        } catch (error) {
-            if (controller.signal.aborted) return;
-            addToast("Failed to load projects.", "error");
-        } finally {
-            if (controller.signal.aborted) return;
-            setLoading(false);
-        }
-    }, [user, addToast]);
+    setLoading(true);
+    try {
+      if (!user.companyId) return;
+      let projectsPromise: Promise<Project[]>;
+      if (hasPermission(user, Permission.VIEW_ALL_PROJECTS)) {
+        projectsPromise = api.getProjectsByCompany(user.companyId, { signal: controller.signal });
+      } else {
+        projectsPromise = api.getProjectsByUser(user.id, { signal: controller.signal });
+      }
+      const fetchedProjects = await projectsPromise;
+      if (controller.signal.aborted) return;
+      setProjects(fetchedProjects);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      addToast('Failed to load projects.', 'error');
+    } finally {
+      if (controller.signal.aborted) return;
+      setLoading(false);
+    }
+  }, [user, addToast]);
 
-    useEffect(() => {
-        fetchData();
-        return () => {
-            abortControllerRef.current?.abort();
-        };
-    }, [fetchData]);
-    
-    const filteredProjects = useMemo(() => {
-        if (filter === 'ALL') return projects;
-        return projects.filter(p => p.status === filter);
-    }, [projects, filter]);
-
-    const portfolioSummary = useMemo(() => {
-        if (projects.length === 0) {
-            return {
-                total: 0,
-                active: 0,
-                atRisk: 0,
-                pipelineValue: 0,
-            };
-        }
-
-        const active = projects.filter(p => p.status === 'ACTIVE').length;
-        const atRisk = projects.filter(p => p.actualCost > p.budget).length;
-        const pipelineValue = projects.reduce((acc, project) => acc + project.budget, 0);
-
-        return {
-            total: projects.length,
-            active,
-            atRisk,
-            pipelineValue,
-        };
-    }, [projects]);
-
-    const handleSuccess = (newProject: Project) => {
-        setProjects(prev => [...prev, newProject]);
-        onSelectProject(newProject);
+  useEffect(() => {
+    fetchData();
+    return () => {
+      abortControllerRef.current?.abort();
     };
+  }, [fetchData]);
 
-    if (loading) return <Card><p>Loading projects...</p></Card>;
+  const filteredProjects = useMemo(() => {
+    if (filter === 'ALL') return projects;
+    return projects.filter(p => p.status === filter);
+  }, [projects, filter]);
 
-    const activeShare = portfolioSummary.total > 0 ? Math.round((portfolioSummary.active / portfolioSummary.total) * 100) : 0;
+  const portfolioSummary = useMemo(() => {
+    if (projects.length === 0) {
+      return {
+        total: 0,
+        active: 0,
+        atRisk: 0,
+        pipelineValue: 0,
+      };
+    }
 
-    return (
-        <div className="space-y-6">
-            {isCreateModalOpen && (
-                <ProjectModal
-                    user={user}
-                    onClose={() => setIsCreateModalOpen(false)}
-                    onSuccess={handleSuccess}
-                    addToast={addToast}
-                />
-            )}
-            <ViewHeader
-                view="projects"
-                actions={canCreate ? <Button onClick={() => setIsCreateModalOpen(true)}>Create Project</Button> : undefined}
-                meta={[
-                    {
-                        label: 'Portfolio value',
-                        value: formatCurrency(portfolioSummary.pipelineValue),
-                        helper: 'Budgeted across all projects',
-                    },
-                    {
-                        label: 'Active projects',
-                        value: `${portfolioSummary.active}`,
-                        helper: portfolioSummary.total > 0 ? `${activeShare}% of portfolio` : 'No projects yet',
-                        indicator: portfolioSummary.active > 0 ? 'positive' : 'neutral',
-                    },
-                    {
-                        label: 'Over budget',
-                        value: `${portfolioSummary.atRisk}`,
-                        helper: portfolioSummary.atRisk > 0 ? 'Requires commercial review' : 'No overruns detected',
-                        indicator: portfolioSummary.atRisk > 0 ? 'negative' : 'positive',
-                    },
-                ]}
-            />
+    const active = projects.filter(p => p.status === 'ACTIVE').length;
+    const atRisk = projects.filter(p => p.actualCost > p.budget).length;
+    const pipelineValue = projects.reduce((acc, project) => acc + project.budget, 0);
 
-            <div className="flex flex-wrap gap-2">
-                {PROJECT_FILTERS.map(filterOption => (
-                    <button
-                        key={filterOption.value}
-                        onClick={() => setFilter(filterOption.value)}
-                        className={`rounded-full px-3 py-1.5 text-sm transition-colors ${
-                            filter === filterOption.value
-                                ? 'bg-primary text-primary-foreground shadow-sm'
-                                : 'bg-muted text-muted-foreground hover:bg-muted/80'
-                        }`}
-                    >
-                        {filterOption.label}
-                    </button>
-                ))}
-            </div>
+    return {
+      total: projects.length,
+      active,
+      atRisk,
+      pipelineValue,
+    };
+  }, [projects]);
 
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-                {filteredProjects.map(project => (
-                    <ProjectCard key={project.id} project={project} onSelect={() => onSelectProject(project)} />
-                ))}
-            </div>
-        </div>
-    );
+  const handleSuccess = (newProject: Project) => {
+    setProjects(prev => [...prev, newProject]);
+    onSelectProject(newProject);
+  };
+
+  if (loading) return <Card><p>Loading projects...</p></Card>;
+
+  const activeShare = portfolioSummary.total > 0 ? Math.round((portfolioSummary.active / portfolioSummary.total) * 100) : 0;
+
+  return (
+    <div className="space-y-6">
+      {isCreateModalOpen && (
+        <ProjectModal
+          user={user}
+          onClose={() => setIsCreateModalOpen(false)}
+          onSuccess={handleSuccess}
+          addToast={addToast}
+        />
+      )}
+      <ViewHeader
+        view="projects"
+        actions={canCreate ? <Button onClick={() => setIsCreateModalOpen(true)}>Create Project</Button> : undefined}
+        meta={[
+          {
+            label: 'Portfolio value',
+            value: formatCurrency(portfolioSummary.pipelineValue),
+            helper: 'Budgeted across all projects',
+          },
+          {
+            label: 'Active projects',
+            value: `${portfolioSummary.active}`,
+            helper: portfolioSummary.total > 0 ? `${activeShare}% of portfolio` : 'No projects yet',
+            indicator: portfolioSummary.active > 0 ? 'positive' : 'neutral',
+          },
+          {
+            label: 'Over budget',
+            value: `${portfolioSummary.atRisk}`,
+            helper: portfolioSummary.atRisk > 0 ? 'Requires commercial review' : 'No overruns detected',
+            indicator: portfolioSummary.atRisk > 0 ? 'negative' : 'positive',
+          },
+        ]}
+      />
+
+      <div className="flex flex-wrap gap-2">
+        {PROJECT_FILTERS.map(filterOption => (
+          <button
+            key={filterOption.value}
+            onClick={() => setFilter(filterOption.value)}
+            className={`rounded-full px-3 py-1.5 text-sm transition-colors ${
+              filter === filterOption.value
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80'
+            }`}
+          >
+            {filterOption.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        {filteredProjects.map(project => (
+          <ProjectCard key={project.id} project={project} onSelect={() => onSelectProject(project)} />
+        ))}
+      </div>
+    </div>
+  );
 };

--- a/components/layout/ViewAccessBoundary.tsx
+++ b/components/layout/ViewAccessBoundary.tsx
@@ -61,21 +61,6 @@ const PermissionRequirements: React.FC<{ permissions: Permission[]; anyGroups: P
           </div>
         </div>
       ))}
-
-const PermissionList: React.FC<{ permissions: Permission[] }> = ({ permissions }) => {
-  const uniquePermissions = Array.from(new Set(permissions));
-
-  if (uniquePermissions.length === 0) return null;
-
-  return (
-    <div className="space-y-2">
-      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Required permissions</p>
-      <div className="flex flex-wrap gap-2">
-        {uniquePermissions.map((permission) => (
-          <Tag key={permission} label={humanise(permission)} color="red" statusIndicator="red" />
-        ))}
-      </div>
- main
     </div>
   );
 };
@@ -148,7 +133,6 @@ export const ViewAccessBoundary: React.FC<ViewAccessBoundaryProps> = ({
 
           <PermissionRequirements permissions={access.missingPermissions} anyGroups={access.missingAnyPermissionGroups} />
 
-          <PermissionList permissions={access.missingPermissions} />
           <AllowedRoleList roles={access.allowedRoles} />
 
           {onNavigate ? (

--- a/services/ai.ts
+++ b/services/ai.ts
@@ -1,5 +1,20 @@
 import { GoogleGenAI, GenerateContentResponse } from '@google/genai';
-import { Project, Todo, SafetyIncident, Expense, Document, User, TodoStatus, IncidentSeverity } from '../types';
+import {
+  Project,
+  Todo,
+  SafetyIncident,
+  Expense,
+  Document,
+  User,
+  TodoStatus,
+  IncidentSeverity,
+  FinancialKPIs,
+  MonthlyFinancials,
+  CostBreakdown,
+  Invoice,
+  InvoiceStatus,
+  ExpenseStatus,
+} from '../types';
 
 const MODEL_NAME = 'gemini-2.0-flash-001';
 const API_KEY = typeof import.meta !== 'undefined' && import.meta.env?.VITE_GEMINI_API_KEY
@@ -61,6 +76,15 @@ const formatCurrency = (value: number, currency: string = 'GBP') =>
   new Intl.NumberFormat('en-GB', { style: 'currency', currency, maximumFractionDigits: 0 }).format(value);
 
 const clampPercentage = (value: number) => Math.max(0, Math.min(100, Math.round(value)));
+
+const formatSignedPercentage = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return '0%';
+  }
+  const rounded = Number(value.toFixed(1));
+  const prefix = rounded > 0 ? '+' : '';
+  return `${prefix}${rounded}%`;
+};
 
 const inferHealthStatus = (progress: number, budgetUtilisation: number, openIncidents: number) => {
   if (budgetUtilisation > 110 || progress < 40) {
@@ -379,4 +403,222 @@ Respond with concise Markdown. Prioritise actionable insights, references to doc
   }
 
   return buildFallbackSearch(input);
+};
+
+interface FinancialSnapshot {
+  monthsCount: number;
+  averageProfit: number;
+  lastProfit: number;
+  profitTrendPct: number;
+  openInvoiceBalance: number;
+  approvedExpenseTotal: number;
+  approvedExpenseRunRate: number;
+  cashFlow: number;
+  currency: string;
+  projectedCash: number;
+}
+
+export interface FinancialForecastInput {
+  companyName: string;
+  currency?: string;
+  horizonMonths: number;
+  kpis?: FinancialKPIs | null;
+  monthly?: MonthlyFinancials[];
+  costs?: CostBreakdown[];
+  invoices?: Invoice[];
+  expenses?: Expense[];
+}
+
+export interface FinancialForecastResult {
+  summary: string;
+  model?: string;
+  isFallback: boolean;
+  metadata: Record<string, unknown>;
+}
+
+const computeFinancialSnapshot = (input: FinancialForecastInput, horizonMonths: number): FinancialSnapshot => {
+  const monthly = input.monthly ?? [];
+  const profits = monthly.map(entry => entry.profit ?? 0);
+  const monthsCount = monthly.length;
+
+  const totalProfit = profits.reduce((sum, value) => sum + value, 0);
+  const averageProfit = monthsCount > 0 ? totalProfit / monthsCount : 0;
+  const lastProfit = monthsCount > 0 ? profits[monthsCount - 1] : 0;
+  const previousProfit = monthsCount > 1 ? profits[monthsCount - 2] : lastProfit;
+  const rawTrend = monthsCount > 1 && previousProfit !== 0 ? ((lastProfit - previousProfit) / Math.abs(previousProfit)) * 100 : 0;
+  const profitTrendPct = Number.isFinite(rawTrend) ? rawTrend : 0;
+
+  const openInvoiceBalance = (input.invoices ?? []).reduce((sum, invoice) => {
+    if (!invoice || invoice.status === InvoiceStatus.PAID || invoice.status === InvoiceStatus.CANCELLED) {
+      return sum;
+    }
+    const balance = typeof invoice.balance === 'number'
+      ? invoice.balance
+      : Math.max((invoice.total ?? 0) - (invoice.amountPaid ?? 0), 0);
+    return sum + balance;
+  }, 0);
+
+  const approvedExpenseTotal = (input.expenses ?? [])
+    .filter(expense => expense.status === ExpenseStatus.APPROVED || expense.status === ExpenseStatus.PAID)
+    .reduce((sum, expense) => sum + (expense.amount ?? 0), 0);
+
+  const approvedExpenseRunRate = monthsCount > 0 ? approvedExpenseTotal / monthsCount : approvedExpenseTotal;
+
+  const cashFlow = input.kpis?.cashFlow ?? 0;
+  const currency = input.currency || input.kpis?.currency || 'GBP';
+  const projectedCash = cashFlow + horizonMonths * (averageProfit - approvedExpenseRunRate);
+
+  return {
+    monthsCount,
+    averageProfit,
+    lastProfit,
+    profitTrendPct,
+    openInvoiceBalance,
+    approvedExpenseTotal,
+    approvedExpenseRunRate,
+    cashFlow,
+    currency,
+    projectedCash,
+  };
+};
+
+const buildForecastContext = (input: FinancialForecastInput, snapshot: FinancialSnapshot): string => {
+  const monthlyLines = (input.monthly ?? [])
+    .map(entry => `- ${entry.month}: revenue ${formatCurrency(entry.revenue, snapshot.currency)}, profit ${formatCurrency(entry.profit, snapshot.currency)}`)
+    .join('\n');
+
+  const costLines = (input.costs ?? [])
+    .map(cost => `- ${cost.category}: ${formatCurrency(cost.amount, snapshot.currency)}`)
+    .join('\n');
+
+  const invoiceLines = (input.invoices ?? [])
+    .filter(invoice => invoice.status !== InvoiceStatus.PAID && invoice.status !== InvoiceStatus.CANCELLED)
+    .slice(0, 8)
+    .map(invoice => {
+      const balance = typeof invoice.balance === 'number'
+        ? invoice.balance
+        : Math.max((invoice.total ?? 0) - (invoice.amountPaid ?? 0), 0);
+      const identifier = invoice.invoiceNumber || invoice.id;
+      return `- ${identifier}: ${invoice.status} • total ${formatCurrency(invoice.total ?? 0, snapshot.currency)} • balance ${formatCurrency(balance, snapshot.currency)}`;
+    })
+    .join('\n');
+
+  const expenseLines = (input.expenses ?? [])
+    .filter(expense => expense.status === ExpenseStatus.APPROVED || expense.status === ExpenseStatus.PAID)
+    .slice(0, 8)
+    .map(expense => `- ${expense.description}: ${formatCurrency(expense.amount, expense.currency || snapshot.currency)} (${expense.status})`)
+    .join('\n');
+
+  return `Company: ${input.companyName}
+Currency in use: ${snapshot.currency}
+Planning horizon: ${input.horizonMonths} month(s)
+Current KPIs: profitability ${typeof input.kpis?.profitability === 'number' ? `${input.kpis.profitability}%` : 'n/a'}, project margin ${typeof input.kpis?.projectMargin === 'number' ? `${input.kpis.projectMargin}%` : 'n/a'}, cash flow ${formatCurrency(snapshot.cashFlow, snapshot.currency)}
+
+Monthly revenue and profit history:
+${monthlyLines || 'No monthly history captured.'}
+
+Cost allocation snapshot:
+${costLines || 'No cost breakdown provided.'}
+
+Outstanding invoices:
+${invoiceLines || 'All invoices are settled.'}
+
+Approved or paid expenses:
+${expenseLines || 'No approved expenses logged.'}
+
+Derived metrics:
+- Average monthly profit: ${formatCurrency(snapshot.averageProfit, snapshot.currency)}
+- Profit trend vs prior month: ${formatSignedPercentage(snapshot.profitTrendPct)}
+- Open invoice balance: ${formatCurrency(snapshot.openInvoiceBalance, snapshot.currency)}
+- Expense run rate: ${formatCurrency(snapshot.approvedExpenseRunRate, snapshot.currency)} per month
+- Projected cash position (${input.horizonMonths} mo): ${formatCurrency(snapshot.projectedCash, snapshot.currency)}
+- Notes: Focus on actionable recommendations and highlight risks to runway.`;
+};
+
+const buildFallbackFinancialForecast = (
+  input: FinancialForecastInput,
+  snapshot: FinancialSnapshot,
+): FinancialForecastResult => {
+  const historyLabel = snapshot.monthsCount > 0
+    ? `${snapshot.monthsCount} month${snapshot.monthsCount === 1 ? '' : 's'} of trading`
+    : 'limited trading data';
+
+  const summary = [
+    `**${input.companyName}** – ${input.horizonMonths}-month financial outlook`,
+    `- Average profit: ${formatCurrency(snapshot.averageProfit, snapshot.currency)} per month (${historyLabel}).`,
+    `- Cash position: ${formatCurrency(snapshot.cashFlow, snapshot.currency)} on hand with projected runway ${formatCurrency(snapshot.projectedCash, snapshot.currency)} after ${input.horizonMonths} month(s).`,
+    `- Trend: ${snapshot.profitTrendPct === 0 ? 'Flat' : snapshot.profitTrendPct > 0 ? 'Improving' : 'Softening'} ${formatSignedPercentage(snapshot.profitTrendPct)} versus last month.`,
+    `- Pipeline vs. spend: ${formatCurrency(snapshot.openInvoiceBalance, snapshot.currency)} outstanding invoices; monthly approved spend about ${formatCurrency(snapshot.approvedExpenseRunRate, snapshot.currency)}.`,
+    `- Recommendation: Accelerate collections and hold discretionary costs to protect cash coverage over the planning window.`,
+  ].join('\n');
+
+  return {
+    summary,
+    isFallback: true,
+    metadata: {
+      horizonMonths: input.horizonMonths,
+      averageMonthlyProfit: snapshot.averageProfit,
+      projectedCash: snapshot.projectedCash,
+      profitTrendPct: Number(Number.isFinite(snapshot.profitTrendPct) ? snapshot.profitTrendPct.toFixed(1) : '0'),
+      openInvoiceBalance: snapshot.openInvoiceBalance,
+      approvedExpenseRunRate: snapshot.approvedExpenseRunRate,
+      cashFlow: snapshot.cashFlow,
+      currency: snapshot.currency,
+      isFallback: true,
+    },
+  };
+};
+
+export const generateFinancialForecast = async (
+  input: FinancialForecastInput,
+): Promise<FinancialForecastResult> => {
+  const horizonMonths = Number.isFinite(input.horizonMonths)
+    ? Math.max(1, Math.round(input.horizonMonths))
+    : 3;
+  const snapshot = computeFinancialSnapshot(input, horizonMonths);
+
+  const prompt = `You are the CFO co-pilot for a construction company. Draft an actionable cash flow and profitability outlook for the next ${horizonMonths} month(s).
+- Emphasise momentum (improving or declining) and quantify expected profit/runway.
+- Highlight risks, e.g. outstanding invoices or elevated spend, and suggest mitigations.
+- Keep it to 4-5 concise bullet points, using bold sparingly for key figures.
+- Base recommendations strictly on the provided data.
+
+${buildForecastContext({ ...input, horizonMonths }, snapshot)}
+
+Respond in Markdown using bullet points.`;
+
+  const response = await callGemini(prompt, { maxOutputTokens: 768, temperature: 0.3 });
+
+  if (response?.text) {
+    const text = response.text.trim();
+    if (text.length > 0) {
+      const metadata: Record<string, unknown> = {
+        horizonMonths,
+        averageMonthlyProfit: snapshot.averageProfit,
+        projectedCash: snapshot.projectedCash,
+        profitTrendPct: Number(snapshot.profitTrendPct.toFixed(1)),
+        openInvoiceBalance: snapshot.openInvoiceBalance,
+        approvedExpenseRunRate: snapshot.approvedExpenseRunRate,
+        cashFlow: snapshot.cashFlow,
+        currency: snapshot.currency,
+        isFallback: false,
+      };
+
+      if (response.modelVersion) {
+        metadata.modelVersion = response.modelVersion;
+      }
+      if (response.usageMetadata) {
+        metadata.usageMetadata = response.usageMetadata;
+      }
+
+      return {
+        summary: text,
+        model: response.modelVersion ?? MODEL_NAME,
+        isFallback: false,
+        metadata,
+      };
+    }
+  }
+
+  return buildFallbackFinancialForecast({ ...input, horizonMonths }, snapshot);
 };

--- a/services/mockApi.ts
+++ b/services/mockApi.ts
@@ -2,7 +2,58 @@
 // Supports offline queuing for write operations.
 
 import { initialData } from './mockData';
-import { User, Company, Project, Task, TimeEntry, SafetyIncident, Equipment, Client, Invoice, Expense, Notification, LoginCredentials, RegisterCredentials, TaskStatus, TaskPriority, TimeEntryStatus, IncidentSeverity, SiteUpdate, ProjectMessage, Weather, InvoiceStatus, Quote, FinancialKPIs, MonthlyFinancials, CostBreakdown, Role, TimesheetStatus, IncidentStatus, AuditLog, ResourceAssignment, Conversation, Message, CompanySettings, ProjectAssignment, ProjectTemplate, ProjectInsight, WhiteboardNote, BidPackage, RiskAnalysis, Grant, Timesheet, Todo, InvoiceLineItem, Document, UsageMetric, CompanyType, ExpenseStatus, TodoStatus, TodoPriority } from '../types';
+import {
+    User,
+    Company,
+    Project,
+    Task,
+    TimeEntry,
+    SafetyIncident,
+    Equipment,
+    Client,
+    Invoice,
+    Expense,
+    Notification,
+    LoginCredentials,
+    RegisterCredentials,
+    TaskStatus,
+    TaskPriority,
+    TimeEntryStatus,
+    IncidentSeverity,
+    SiteUpdate,
+    ProjectMessage,
+    Weather,
+    InvoiceStatus,
+    Quote,
+    FinancialKPIs,
+    MonthlyFinancials,
+    CostBreakdown,
+    Role,
+    TimesheetStatus,
+    IncidentStatus,
+    AuditLog,
+    ResourceAssignment,
+    Conversation,
+    Message,
+    CompanySettings,
+    ProjectAssignment,
+    ProjectTemplate,
+    ProjectInsight,
+    FinancialForecast,
+    WhiteboardNote,
+    BidPackage,
+    RiskAnalysis,
+    Grant,
+    Timesheet,
+    Todo,
+    InvoiceLineItem,
+    Document,
+    UsageMetric,
+    CompanyType,
+    ExpenseStatus,
+    TodoStatus,
+    TodoPriority,
+} from '../types';
 
 const delay = (ms = 50) => new Promise(res => setTimeout(res, ms));
 
@@ -85,6 +136,7 @@ let db: {
     whiteboardNotes: Partial<WhiteboardNote>[];
     documents: Partial<Document>[];
     projectInsights: Partial<ProjectInsight>[];
+    financialForecasts: Partial<FinancialForecast>[];
 } = {
     companies: hydrateData('companies', initialData.companies),
     users: hydrateData('users', initialData.users),
@@ -109,6 +161,7 @@ let db: {
     whiteboardNotes: hydrateData('whiteboardNotes', []),
     documents: hydrateData('documents', []),
     projectInsights: hydrateData('projectInsights', (initialData as any).projectInsights || []),
+    financialForecasts: hydrateData('financialForecasts', (initialData as any).financialForecasts || []),
 };
 
 const saveDb = () => {
@@ -417,12 +470,18 @@ export const api = {
         ensureNotAborted(options?.signal);
         return db.documents.filter(d => d.projectId === projectId) as Document[];
     },
- codex/add-abort-feature-to-fetchdata
     getUsersByProject: async (projectId: string, options?: RequestOptions): Promise<User[]> => {
-        
-
-    getProjectInsights: async (projectId: string): Promise<ProjectInsight[]> => {
+        ensureNotAborted(options?.signal);
         await delay();
+        ensureNotAborted(options?.signal);
+        const assignments = db.projectAssignments.filter(pa => pa.projectId === projectId);
+        const userIds = new Set(assignments.map(a => a.userId));
+        return db.users.filter(u => userIds.has(u.id!)) as User[];
+    },
+    getProjectInsights: async (projectId: string, options?: RequestOptions): Promise<ProjectInsight[]> => {
+        ensureNotAborted(options?.signal);
+        await delay();
+        ensureNotAborted(options?.signal);
         return db.projectInsights
             .filter(insight => insight.projectId === projectId)
             .sort((a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime())
@@ -466,12 +525,58 @@ export const api = {
         saveDb();
         return newInsight;
     },
-    getUsersByProject: async (projectId: string): Promise<User[]> => {
+    getFinancialForecasts: async (companyId: string, options?: RequestOptions): Promise<FinancialForecast[]> => {
+        ensureNotAborted(options?.signal);
         await delay();
         ensureNotAborted(options?.signal);
-        const assignments = db.projectAssignments.filter(pa => pa.projectId === projectId);
-        const userIds = new Set(assignments.map(a => a.userId));
-        return db.users.filter(u => userIds.has(u.id!)) as User[];
+        return db.financialForecasts
+            .filter(forecast => forecast.companyId === companyId)
+            .sort((a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime())
+            .map(forecast => ({
+                id: forecast.id!,
+                companyId: forecast.companyId!,
+                summary: forecast.summary || '',
+                horizonMonths: typeof forecast.horizonMonths === 'number'
+                    ? forecast.horizonMonths
+                    : Number((forecast.metadata as any)?.horizonMonths) || 3,
+                createdAt: forecast.createdAt || new Date().toISOString(),
+                createdBy: forecast.createdBy || 'system',
+                model: forecast.model,
+                metadata: forecast.metadata,
+            }));
+    },
+    createFinancialForecast: async (
+        data: { companyId: string; summary: string; horizonMonths: number; metadata?: Record<string, unknown>; model?: string },
+        userId: string,
+    ): Promise<FinancialForecast> => {
+        await delay();
+        if (!data.companyId) {
+            throw new Error('companyId is required to create a financial forecast.');
+        }
+        if (!data.summary.trim()) {
+            throw new Error('summary is required to create a financial forecast.');
+        }
+
+        const newForecast: FinancialForecast = {
+            id: String(Date.now() + Math.random()),
+            companyId: data.companyId,
+            summary: data.summary,
+            horizonMonths: data.horizonMonths,
+            createdAt: new Date().toISOString(),
+            createdBy: userId,
+            model: data.model,
+            metadata: data.metadata,
+        };
+
+        db.financialForecasts.push(newForecast);
+        const company = db.companies.find(c => c.id === data.companyId);
+        addAuditLog(
+            userId,
+            'generated_financial_forecast',
+            company ? { type: 'company', id: company.id!, name: company.name || '' } : undefined,
+        );
+        saveDb();
+        return newForecast;
     },
     getExpensesByCompany: async (companyId: string, options?: RequestOptions): Promise<Expense[]> => {
         ensureNotAborted(options?.signal);

--- a/services/mockData.ts
+++ b/services/mockData.ts
@@ -2,7 +2,47 @@
 
 // FIX: Added missing type imports to allow for explicit typing of mock data arrays.
 // FIX: Replaced UserRole with Role
-import { Company, User, Project, ProjectAssignment, Task, Timesheet, SafetyIncident, Equipment, ResourceAssignment, Client, Invoice, Quote, Expense, ProjectTemplate, ProjectInsight, Notification, AuditLog, Conversation, Message, Document, Role, TodoStatus, TimesheetStatus, IncidentStatus, IncidentSeverity, TodoPriority, InvoiceStatus, QuoteStatus, ExpenseCategory, ExpenseStatus, NotificationType, DocumentStatus, EquipmentStatus, AvailabilityStatus, WhiteboardNote, SiteUpdate, ProjectMessage, Todo } from '../types';
+import {
+  Company,
+  User,
+  Project,
+  ProjectAssignment,
+  Task,
+  Timesheet,
+  SafetyIncident,
+  Equipment,
+  ResourceAssignment,
+  Client,
+  Invoice,
+  Quote,
+  Expense,
+  ProjectTemplate,
+  ProjectInsight,
+  FinancialForecast,
+  Notification,
+  AuditLog,
+  Conversation,
+  Message,
+  Document,
+  Role,
+  TodoStatus,
+  TimesheetStatus,
+  IncidentStatus,
+  IncidentSeverity,
+  TodoPriority,
+  InvoiceStatus,
+  QuoteStatus,
+  ExpenseCategory,
+  ExpenseStatus,
+  NotificationType,
+  DocumentStatus,
+  EquipmentStatus,
+  AvailabilityStatus,
+  WhiteboardNote,
+  SiteUpdate,
+  ProjectMessage,
+  Todo,
+} from '../types';
 
 export const initialData = {
     companies: [
@@ -55,6 +95,7 @@ export const initialData = {
         { id: 'te-1', userId: '4', projectId: '101', startTime: new Date(Date.now() - 8 * 3600 * 1000).toISOString(), endTime: new Date().toISOString(), status: TimesheetStatus.PENDING }
     ] as Partial<Timesheet>[],
     projectInsights: [] as Partial<ProjectInsight>[],
+    financialForecasts: [] as Partial<FinancialForecast>[],
     clients: [
         { id: 'c-1', name: 'Global Real Estate Inc.', email: 'contact@gre.com', phone: '555-0101', companyId: '1' }
     ] as Partial<Client>[],

--- a/types.ts
+++ b/types.ts
@@ -369,6 +369,17 @@ export interface ProjectInsight {
   metadata?: Record<string, unknown>;
 }
 
+export interface FinancialForecast {
+  id: string;
+  companyId: string;
+  summary: string;
+  horizonMonths: number;
+  createdAt: string;
+  createdBy: string;
+  model?: string;
+  metadata?: Record<string, unknown>;
+}
+
 // FIX: Renamed Task to Todo for consistency with component usage.
 export interface Todo {
   id: string;

--- a/utils/viewAccess.ts
+++ b/utils/viewAccess.ts
@@ -219,7 +219,6 @@ export const evaluateViewAccess = (user: User, view: View): ViewAccessEvaluation
       allowed: true,
       missingPermissions: [],
       missingAnyPermissionGroups: [],
-
     };
   }
 
@@ -229,8 +228,6 @@ export const evaluateViewAccess = (user: User, view: View): ViewAccessEvaluation
       allowed: false,
       missingPermissions: [],
       missingAnyPermissionGroups: [],
-
- main
       allowedRoles: rule.allowedRoles,
       reason: rule.description,
       fallbackView: rule.fallbackView,
@@ -238,35 +235,27 @@ export const evaluateViewAccess = (user: User, view: View): ViewAccessEvaluation
   }
 
   const missingPermissions: Permission[] = [];
- codex/enhance-ui-and-design-for-integration-t494d2
   const missingAnyGroups: Permission[][] = [];
 
- 
-
   if (rule.anyPermissions) {
-    const hasAny = rule.anyPermissions.some((permission) => hasPermission(user, permission));
+    const hasAny = rule.anyPermissions.some(permission => hasPermission(user, permission));
     if (!hasAny) {
       missingAnyGroups.push(rule.anyPermissions);
-
       missingPermissions.push(...rule.anyPermissions);
     }
   }
 
   if (rule.allPermissions) {
-    const missing = rule.allPermissions.filter((permission) => !hasPermission(user, permission));
+    const missing = rule.allPermissions.filter(permission => !hasPermission(user, permission));
     missingPermissions.push(...missing);
   }
 
   if (missingPermissions.length > 0 || missingAnyGroups.length > 0) {
-
-  if (missingPermissions.length > 0) {
     return {
       view,
       allowed: false,
       missingPermissions,
       missingAnyPermissionGroups: missingAnyGroups,
-
- main
       reason: rule.description,
       fallbackView: rule.fallbackView,
     };
@@ -276,9 +265,7 @@ export const evaluateViewAccess = (user: User, view: View): ViewAccessEvaluation
     view,
     allowed: true,
     missingPermissions: [],
- codex/enhance-ui-and-design-for-integration-t494d2
-
- main
+    missingAnyPermissionGroups: [],
   };
 };
 


### PR DESCRIPTION
## Summary
- add a Gemini-powered cash-flow outlook panel and history to the financials dashboard with offline-aware UI feedback
- extend the AI service with a financial forecast generator and fallback metrics capture
- persist company financial forecasts via the mock API, seed data, and shared FinancialForecast type

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c8e268beac8327b9e52712fb8d491d