### PR TITLE
Improve notification handling and project browsing

### DIFF
--- a/components/ProjectsView.tsx
+++ b/components/ProjectsView.tsx
@@ -22,6 +22,16 @@ const statusAccent: Record<ProjectStatus, { bg: string; text: string }> = {
   CANCELLED: { bg: 'bg-slate-500/10', text: 'text-slate-500 dark:text-slate-300' },
 };
 
+type SortKey = 'startDate' | 'endDate' | 'name' | 'budget' | 'progress';
+
+const SORT_OPTIONS: Array<{ value: SortKey; label: string }> = [
+  { value: 'startDate', label: 'Start date' },
+  { value: 'endDate', label: 'End date' },
+  { value: 'name', label: 'Name' },
+  { value: 'budget', label: 'Budget' },
+  { value: 'progress', label: 'Progress' },
+];
+
 const formatCurrency = (value: number): string =>
   new Intl.NumberFormat('en-GB', {
     style: 'currency',
@@ -98,6 +108,9 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({ user, addToast, onSe
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<'ALL' | ProjectStatus>('ALL');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('startDate');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -137,9 +150,68 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({ user, addToast, onSe
   }, [fetchData]);
 
   const filteredProjects = useMemo(() => {
-    if (filter === 'ALL') return projects;
-    return projects.filter(p => p.status === filter);
-  }, [projects, filter]);
+    const baseProjects = filter === 'ALL' ? projects : projects.filter(p => p.status === filter);
+    const query = searchQuery.trim().toLowerCase();
+
+    const searchedProjects = query
+      ? baseProjects.filter(project => {
+          const fields = [
+            project.name,
+            project.location?.address,
+            project.projectType,
+            project.workClassification,
+          ].filter(Boolean) as string[];
+          return fields.some(field => field.toLowerCase().includes(query));
+        })
+      : baseProjects;
+
+    const direction = sortDirection === 'asc' ? 1 : -1;
+
+    const sortedProjects = [...searchedProjects].sort((a, b) => {
+      let comparison = 0;
+      switch (sortKey) {
+        case 'name':
+          comparison = a.name.localeCompare(b.name);
+          break;
+        case 'startDate':
+          comparison = new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
+          break;
+        case 'endDate':
+          comparison = new Date(a.endDate).getTime() - new Date(b.endDate).getTime();
+          break;
+        case 'budget':
+          comparison = (a.budget ?? 0) - (b.budget ?? 0);
+          break;
+        case 'progress':
+          comparison = (a.progress ?? 0) - (b.progress ?? 0);
+          break;
+        default:
+          comparison = 0;
+      }
+
+      if (Number.isNaN(comparison)) {
+        comparison = 0;
+      }
+
+      if (comparison === 0 && sortKey !== 'name') {
+        comparison = a.name.localeCompare(b.name);
+      }
+
+      return comparison * direction;
+    });
+
+    return sortedProjects;
+  }, [projects, filter, searchQuery, sortDirection, sortKey]);
+
+  const hasActiveFilters =
+    filter !== 'ALL' || searchQuery.trim() !== '' || sortKey !== 'startDate' || sortDirection !== 'asc';
+
+  const handleResetFilters = () => {
+    setFilter('ALL');
+    setSearchQuery('');
+    setSortKey('startDate');
+    setSortDirection('asc');
+  };
 
   const portfolioSummary = useMemo(() => {
     if (projects.length === 0) {
@@ -206,6 +278,60 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({ user, addToast, onSe
         ]}
       />
 
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="relative w-full md:max-w-sm">
+          <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-muted-foreground">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </span>
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={event => setSearchQuery(event.target.value)}
+            placeholder="Search by name, location, or type..."
+            className="w-full rounded-md border border-border bg-background py-2 pl-10 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <label htmlFor="project-sort" className="text-sm font-medium text-muted-foreground">
+            Sort by
+          </label>
+          <select
+            id="project-sort"
+            value={sortKey}
+            onChange={event => setSortKey(event.target.value as SortKey)}
+            className="rounded-md border border-border bg-background py-2 pl-3 pr-8 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          >
+            {SORT_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => setSortDirection(prev => (prev === 'asc' ? 'desc' : 'asc'))}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary"
+            aria-label={`Sort ${sortDirection === 'asc' ? 'descending' : 'ascending'}`}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              className={`h-4 w-4 transition-transform ${sortDirection === 'desc' ? 'rotate-180' : ''}`}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8 7l4-4 4 4M8 17l4 4 4-4" />
+            </svg>
+          </button>
+          <Button type="button" variant="ghost" size="sm" onClick={handleResetFilters} disabled={!hasActiveFilters}>
+            Reset
+          </Button>
+        </div>
+      </div>
+
       <div className="flex flex-wrap gap-2">
         {PROJECT_FILTERS.map(filterOption => (
           <button
@@ -222,11 +348,34 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({ user, addToast, onSe
         ))}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-        {filteredProjects.map(project => (
-          <ProjectCard key={project.id} project={project} onSelect={() => onSelectProject(project)} />
-        ))}
-      </div>
+      {projects.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {filteredProjects.length === projects.length
+            ? `Showing all ${projects.length} project${projects.length === 1 ? '' : 's'}.`
+            : `Showing ${filteredProjects.length} of ${projects.length} projects.`}
+        </p>
+      )}
+
+      {filteredProjects.length > 0 ? (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {filteredProjects.map(project => (
+            <ProjectCard key={project.id} project={project} onSelect={() => onSelectProject(project)} />
+          ))}
+        </div>
+      ) : (
+        <Card className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+          <p className="text-sm text-muted-foreground">
+            {projects.length === 0
+              ? 'No projects have been created yet. Create your first project to get started.'
+              : 'No projects match your current filters.'}
+          </p>
+          {projects.length > 0 && (
+            <Button type="button" variant="secondary" size="sm" onClick={handleResetFilters}>
+              Clear filters
+            </Button>
+          )}
+        </Card>
+      )}
     </div>
   );
 };

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -10,11 +10,12 @@ interface HeaderProps {
   onCommandPaletteClick: () => void;
   unreadNotificationCount: number;
   notifications: Notification[];
-  onNotificationClick: (notification: Notification) => void;
-  onMarkAllNotificationsAsRead: () => void;
+  onNotificationClick: (notification: Notification) => Promise<void> | void;
+  onMarkAllNotificationsAsRead: () => Promise<void> | void;
+  addToast: (message: string, type: 'success' | 'error') => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ user, onLogout, onSearchClick, onCommandPaletteClick, unreadNotificationCount, notifications, onNotificationClick, onMarkAllNotificationsAsRead }) => {
+export const Header: React.FC<HeaderProps> = ({ user, onLogout, onSearchClick, onCommandPaletteClick, unreadNotificationCount, notifications, onNotificationClick, onMarkAllNotificationsAsRead, addToast }) => {
     const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
     const [isNotificationMenuOpen, setIsNotificationMenuOpen] = useState(false);
     const userName = `${user.firstName} ${user.lastName}`;
@@ -32,7 +33,16 @@ export const Header: React.FC<HeaderProps> = ({ user, onLogout, onSearchClick, o
                      <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" /></svg>
                      {unreadNotificationCount > 0 && <span className="absolute top-1 right-1 block h-2.5 w-2.5 rounded-full bg-red-500 ring-2 ring-background"></span>}
                 </button>
-                {isNotificationMenuOpen && <NotificationDropdown user={user} notifications={notifications} onClose={() => setIsNotificationMenuOpen(false)} addToast={() => {}} onNotificationClick={onNotificationClick} onMarkAllAsRead={onMarkAllNotificationsAsRead} />}
+                {isNotificationMenuOpen && (
+                    <NotificationDropdown
+                        user={user}
+                        notifications={notifications}
+                        onClose={() => setIsNotificationMenuOpen(false)}
+                        addToast={addToast}
+                        onNotificationClick={onNotificationClick}
+                        onMarkAllAsRead={onMarkAllNotificationsAsRead}
+                    />
+                )}
             </div>
             <div className="relative">
                 <button onClick={() => setIsUserMenuOpen(prev => !prev)} className="flex items-center gap-2">

--- a/components/layout/NotificationDropdown.tsx
+++ b/components/layout/NotificationDropdown.tsx
@@ -7,8 +7,8 @@ interface NotificationDropdownProps {
   notifications: Notification[];
   onClose: () => void;
   addToast: (message: string, type: 'success' | 'error') => void;
-  onNotificationClick: (notification: Notification) => void;
-  onMarkAllAsRead: () => void;
+  onNotificationClick: (notification: Notification) => Promise<void> | void;
+  onMarkAllAsRead: () => Promise<void> | void;
 }
 
 const formatDistanceToNow = (date: Date): string => {
@@ -108,35 +108,66 @@ const NotificationIcon: React.FC<{ type: NotificationType }> = ({ type }) => {
     }
 };
 
-export const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ user, notifications, onClose, addToast, onNotificationClick, onMarkAllAsRead }) => {
-    const hasUnread = notifications.some(n => !n.read);
+export const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ user: _user, notifications, onClose, addToast, onNotificationClick, onMarkAllAsRead }) => {
+    const [isMarkingAll, setIsMarkingAll] = React.useState(false);
+    const hasUnread = notifications.some(n => !(n.isRead ?? n.read));
+
+    const handleNotificationSelect = async (notification: Notification) => {
+        try {
+            await onNotificationClick(notification);
+        } catch (error) {
+            console.error('Failed to open notification', error);
+            addToast('Unable to open that notification. Please try again.', 'error');
+            return;
+        }
+        onClose();
+    };
+
+    const handleMarkAllClick = async () => {
+        if (!hasUnread || isMarkingAll) return;
+        try {
+            setIsMarkingAll(true);
+            await onMarkAllAsRead();
+            addToast('All notifications marked as read.', 'success');
+        } catch (error) {
+            console.error('Failed to mark notifications as read', error);
+            addToast('Unable to mark notifications as read. Please try again.', 'error');
+        } finally {
+            setIsMarkingAll(false);
+        }
+    };
 
     return (
         <div className="absolute right-0 mt-2 w-80 sm:w-96 bg-card rounded-md shadow-lg border border-border z-20 flex flex-col max-h-[80vh]">
             <div className="p-4 border-b border-border flex justify-between items-center">
                 <h3 className="font-semibold text-lg text-card-foreground">Notifications</h3>
-                <Button variant="ghost" size="sm" onClick={onMarkAllAsRead} disabled={!hasUnread}>Mark all as read</Button>
+                <Button variant="ghost" size="sm" onClick={handleMarkAllClick} disabled={!hasUnread || isMarkingAll}>
+                    {isMarkingAll ? 'Marking...' : 'Mark all as read'}
+                </Button>
             </div>
             <div className="overflow-y-auto">
                 {notifications.length === 0 ? (
                     <p className="p-8 text-center text-muted-foreground">You have no notifications.</p>
                 ) : (
-                    notifications.map(n => (
-                        <div
-                            key={n.id}
-                            onClick={() => onNotificationClick(n)}
-                            className={`flex items-start gap-3 p-4 border-b border-border hover:bg-accent cursor-pointer ${!n.read ? 'bg-primary/10' : ''}`}
-                        >
-                            {!n.read && <div className="w-2 h-2 rounded-full bg-primary mt-1.5 flex-shrink-0"></div>}
-                            <div className={`flex-shrink-0 ${n.read ? 'ml-4' : ''}`}>
-                                <NotificationIcon type={n.type} />
+                    notifications.map(n => {
+                        const isRead = n.isRead ?? n.read;
+                        return (
+                            <div
+                                key={n.id}
+                                onClick={() => handleNotificationSelect(n)}
+                                className={`flex items-start gap-3 p-4 border-b border-border hover:bg-accent cursor-pointer ${!isRead ? 'bg-primary/10' : ''}`}
+                            >
+                                {!isRead && <div className="w-2 h-2 rounded-full bg-primary mt-1.5 flex-shrink-0"></div>}
+                                <div className={`flex-shrink-0 ${isRead ? 'ml-4' : ''}`}>
+                                    <NotificationIcon type={n.type} />
+                                </div>
+                                <div className="flex-grow">
+                                    <p className="text-sm text-card-foreground">{n.message}</p>
+                                    <p className="text-xs text-muted-foreground mt-1">{formatDistanceToNow(new Date(n.createdAt))} ago</p>
+                                </div>
                             </div>
-                            <div className="flex-grow">
-                                <p className="text-sm text-card-foreground">{n.message}</p>
-                                <p className="text-xs text-muted-foreground mt-1">{formatDistanceToNow(new Date(n.createdAt))} ago</p>
-                            </div>
-                        </div>
-                    ))
+                        );
+                    })
                 )}
             </div>
         </div>

--- a/services/mockApi.ts
+++ b/services/mockApi.ts
@@ -374,11 +374,28 @@ export const api = {
         });
         saveDb();
     },
+    markNotificationAsRead: async (notificationId: string): Promise<void> => {
+        await delay();
+        const notification = db.notifications.find(n => n.id === notificationId);
+        if (!notification) {
+            throw new Error('Notification not found');
+        }
+        notification.isRead = true;
+        notification.read = true;
+        saveDb();
+    },
     getProjectsByManager: async (managerId: string, options?: RequestOptions): Promise<Project[]> => {
         ensureNotAborted(options?.signal);
         await delay();
         ensureNotAborted(options?.signal);
         return db.projects.filter(p => (p as any).managerId === managerId) as Project[];
+    },
+    getProjectById: async (projectId: string, options?: RequestOptions): Promise<Project | null> => {
+        ensureNotAborted(options?.signal);
+        await delay();
+        ensureNotAborted(options?.signal);
+        const project = db.projects.find(p => p.id === projectId);
+        return project ? project as Project : null;
     },
     getUsersByCompany: async (companyId: string, options?: RequestOptions): Promise<User[]> => {
         ensureNotAborted(options?.signal);


### PR DESCRIPTION
## Summary
- add an application-level notification handler that marks items as read and deep-links into related views, backed by new mock API helpers
- refresh the notification dropdown/header integration to support async mark-all, consistent read state, and toast feedback
- enhance the projects screen with search, sort, and reset controls so users can quickly find matching work

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c8ff8b41f483278d43f6cdafde57c3