### PR TITLE
Integrate navigation refinements and projects filtering

### DIFF
--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -9,6 +9,7 @@ interface CommandPaletteProps {
   user: User;
   onClose: () => void;
   setActiveView: (view: View) => void;
+  onProjectSelect: (project: Project) => void;
 }
 
 interface Command {
@@ -21,7 +22,7 @@ interface Command {
   icon: React.ReactNode;
 }
 
-export const CommandPalette: React.FC<CommandPaletteProps> = ({ user, onClose, setActiveView }) => {
+export const CommandPalette: React.FC<CommandPaletteProps> = ({ user, onClose, setActiveView, onProjectSelect }) => {
     const [search, setSearch] = useState('');
     const [projects, setProjects] = useState<Project[]>([]);
     const [activeIndex, setActiveIndex] = useState(0);
@@ -54,13 +55,13 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ user, onClose, s
             type: 'project',
             title: p.name,
             category: 'Projects',
-            action: () => console.log('Navigate to project', p.id), // Replace with actual navigation
+            action: () => onProjectSelect(p),
             // FIX: Corrected property access for project location
-            keywords: p.location.address,
+            keywords: [p.location?.address, p.projectType, p.status].filter(Boolean).join(' '),
             icon: <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" /></svg>
         }));
         return [...navCommands, ...projectCommands];
-    }, [projects, setActiveView]);
+    }, [projects, setActiveView, onProjectSelect]);
 
     const filteredCommands = useMemo(() => {
         if (!search) return allCommands;
@@ -79,12 +80,15 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ user, onClose, s
     const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
         if (e.key === 'ArrowDown') {
             e.preventDefault();
+            if (filteredCommands.length === 0) return;
             setActiveIndex(i => (i + 1) % filteredCommands.length);
         } else if (e.key === 'ArrowUp') {
             e.preventDefault();
+            if (filteredCommands.length === 0) return;
             setActiveIndex(i => (i - 1 + filteredCommands.length) % filteredCommands.length);
         } else if (e.key === 'Enter') {
             e.preventDefault();
+            if (filteredCommands.length === 0) return;
             if (filteredCommands[activeIndex]) {
                 handleSelect(filteredCommands[activeIndex]);
             }


### PR DESCRIPTION
## Summary
- centralize view navigation logic to keep project selection in sync across the app shell and notification handling
- enhance the command palette so navigation shortcuts work reliably and project commands jump straight into project detail views
- refresh the projects view cards and filters with status-aware styling, an "all projects" toggle, and clearer empty states

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9d32921cc83279ca9f8f78254536a