### PR TITLE
Add configurable auth client with backend fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  quality:
+    name: Install, test, and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test -- --run
+
+      - name: Build application
+        run: npm run build
+        env:
+          VITE_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build static site
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+        env:
+          VITE_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: production
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,62 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: vercel-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      VITE_GEMINI_API_KEY: ${{ secrets.VITE_GEMINI_API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test -- --run
+
+      - name: Ensure Vite Gemini key fallback
+        if: env.VITE_GEMINI_API_KEY == '' && env.GEMINI_API_KEY != ''
+        run: echo "VITE_GEMINI_API_KEY=${GEMINI_API_KEY}" >> $GITHUB_ENV
+
+      - name: Build application
+        run: npm run build
+
+      - name: Pull Vercel environment information
+        run: npx vercel pull --yes --environment=${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy to Vercel
+        id: vercel
+        uses: vercel/action@v3
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          scope: ${{ secrets.VERCEL_ORG_ID }}
+          project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: .
+          prod: ${{ github.ref == 'refs/heads/main' }}
+          prebuilt: true

--- a/README.md
+++ b/README.md
@@ -16,5 +16,18 @@ View your app in AI Studio: https://ai.studio/apps/drive/1bxBJgk2nuKF5tvtdT-YfJQ
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+3. (Optional) Point authentication at a deployed backend by setting `VITE_API_BASE_URL` in `.env.local`. When omitted the app runs in secure local demo mode and persists accounts in browser storage.
+4. Run the app:
    `npm run dev`
+
+### Configure authentication backend
+
+By default the registration and login flows use the encrypted in-browser mock API. Provide a `VITE_API_BASE_URL` in `.env.local` to connect to a real authentication service. If that service becomes unreachable you can allow automatic fallback to the mock implementation by exposing `window.__ASAGENTS_API_BASE_URL__` at runtime or by calling `configureAuthClient({ baseUrl, allowMockFallback: true })` in your initialization code.
+
+## Deployment automation
+
+This project ships with a fully automated CI/CD pipeline backed by GitHub Actions. Pull requests run tests and builds via the [`CI` workflow](.github/workflows/ci.yml), while merges to `main` trigger the [`Deploy to GitHub Pages` workflow](.github/workflows/deploy.yml) to publish the production site.
+
+- **Runbooks & responsibilities**: [docs/deployment-plan.md](docs/deployment-plan.md) details the end-to-end automation flow, operational checklists, and ownership model for engineers, reviewers, QA, and on-call.
+- **Secrets**: store the shared Gemini credential as `GEMINI_API_KEY` in repository secrets; developers keep personal keys in `.env.local` as `VITE_GEMINI_API_KEY`.
+- **Monitoring**: follow the plan's observability section to wire synthetic uptime checks and error tracking so deployments stay production ready.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,15 @@ By default the registration and login flows use the encrypted in-browser mock AP
 
 ## Deployment automation
 
-This project ships with a fully automated CI/CD pipeline backed by GitHub Actions. Pull requests run tests and builds via the [`CI` workflow](.github/workflows/ci.yml), while merges to `main` trigger the [`Deploy to GitHub Pages` workflow](.github/workflows/deploy.yml) to publish the production site.
+This project ships with a fully automated CI/CD pipeline backed by GitHub Actions and Vercel.
 
-- **Runbooks & responsibilities**: [docs/deployment-plan.md](docs/deployment-plan.md) details the end-to-end automation flow, operational checklists, and ownership model for engineers, reviewers, QA, and on-call.
-- **Secrets**: store the shared Gemini credential as `GEMINI_API_KEY` in repository secrets; developers keep personal keys in `.env.local` as `VITE_GEMINI_API_KEY`.
+- Pull requests run tests and builds via the [`CI` workflow](.github/workflows/ci.yml).
+- Previews and production releases are handled by the [`Deploy to Vercel` workflow](.github/workflows/vercel-deploy.yml). Pushes to `main` promote the build to the production environment; pull requests publish preview URLs for QA.
+- The legacy GitHub Pages workflow remains available in [.github/workflows/deploy.yml](.github/workflows/deploy.yml) for static exports if you need an alternative host.
+
+### Operations playbooks & secrets
+
+- **Runbooks & responsibilities**: [docs/deployment-plan.md](docs/deployment-plan.md) outlines the automation flow, operational checklists, and ownership model for engineers, reviewers, QA, and on-call.
+- **Vercel-specific setup**: follow [docs/vercel-deployment.md](docs/vercel-deployment.md) to connect the repository to Vercel and provision the required secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`).
+- **Gemini credentials**: store the shared Gemini credential as `GEMINI_API_KEY` in repository secrets and mirror it to `VITE_GEMINI_API_KEY` (or provide a separate client-safe key). Developers keep personal keys in `.env.local` for local runs.
 - **Monitoring**: follow the plan's observability section to wire synthetic uptime checks and error tracking so deployments stay production ready.

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -3,7 +3,7 @@ import { LoginCredentials } from '../types';
 import { Card } from './ui/Card';
 import { Button } from './ui/Button';
 import { useAuth } from '../contexts/AuthContext';
-import { getStorage } from '../utils/storage';
+import { persistRememberedEmail, readRememberedEmail } from '../utils/authRememberMe';
 import { AuthEnvironmentNotice } from './auth/AuthEnvironmentNotice';
 
 interface LoginProps {
@@ -14,31 +14,6 @@ interface LoginProps {
 type LoginStep = 'credentials' | 'mfa';
 
 const validateEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-
-const REMEMBERED_EMAIL_KEY = 'asagents_remembered_email';
-
-const storage = getStorage();
-
-const readRememberedEmail = () => {
-    try {
-        return storage.getItem(REMEMBERED_EMAIL_KEY) || '';
-    } catch (error) {
-        console.warn('Unable to read remembered email', error);
-        return '';
-    }
-};
-
-const persistRememberedEmail = (shouldRemember: boolean, email: string) => {
-    try {
-        if (shouldRemember && email) {
-            storage.setItem(REMEMBERED_EMAIL_KEY, email);
-        } else {
-            storage.removeItem(REMEMBERED_EMAIL_KEY);
-        }
-    } catch (error) {
-        console.warn('Unable to persist remembered email', error);
-    }
-};
 
 export const Login: React.FC<LoginProps> = ({ onSwitchToRegister, onSwitchToForgotPassword }) => {
     const { login, verifyMfaAndFinalize, error: authError, loading: isLoading } = useAuth();

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -51,7 +51,7 @@ export const Login: React.FC<LoginProps> = ({ onSwitchToRegister, onSwitchToForg
     const [showPassword, setShowPassword] = useState(false);
     
     const [error, setError] = useState<string | null>(null);
-    const [validationErrors, setValidationErrors] = useState<{ email?: string; password?: string, mfa?: string }>({});
+    const [validationErrors, setValidationErrors] = useState<{ email?: string; password?: string; mfa?: string }>({});
     
     const [userId, setUserId] = useState<string | null>(null);
 
@@ -73,6 +73,17 @@ export const Login: React.FC<LoginProps> = ({ onSwitchToRegister, onSwitchToForg
       }
     }, [step]);
     
+    const clearValidationError = (field: 'email' | 'password' | 'mfa') => {
+        setValidationErrors(prev => {
+            if (!prev[field]) {
+                return prev;
+            }
+            const next = { ...prev };
+            delete next[field];
+            return next;
+        });
+    };
+
     const handleCredentialSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         setError(null);
@@ -92,6 +103,14 @@ export const Login: React.FC<LoginProps> = ({ onSwitchToRegister, onSwitchToForg
                 setUserId(res.userId);
                 setStep('mfa');
                 setMfaCode('');
+                setValidationErrors(prev => {
+                    if (!prev.mfa) {
+                        return prev;
+                    }
+                    const next = { ...prev };
+                    delete next.mfa;
+                    return next;
+                });
             } else {
                 persistRememberedEmail(rememberMe, trimmedEmail.toLowerCase());
             }
@@ -129,7 +148,11 @@ export const Login: React.FC<LoginProps> = ({ onSwitchToRegister, onSwitchToForg
             id="email"
             type="email"
             value={email}
-            onChange={e => setEmail(e.target.value)}
+            onChange={e => {
+                setEmail(e.target.value);
+                clearValidationError('email');
+                setError(null);
+            }}
             required
             autoComplete="email"
             className={`mt-1 block w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm ${validationErrors.email ? 'border-destructive' : 'border-border'}`}
@@ -143,7 +166,11 @@ export const Login: React.FC<LoginProps> = ({ onSwitchToRegister, onSwitchToForg
               id="password"
               type={showPassword ? 'text' : 'password'}
               value={password}
-              onChange={e => setPassword(e.target.value)}
+              onChange={e => {
+                  setPassword(e.target.value);
+                  clearValidationError('password');
+                  setError(null);
+              }}
               required
               autoComplete="current-password"
               className={`block w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm pr-12 ${validationErrors.password ? 'border-destructive' : 'border-border'}`}
@@ -187,7 +214,12 @@ export const Login: React.FC<LoginProps> = ({ onSwitchToRegister, onSwitchToForg
             type="text"
             ref={mfaInputRef}
             value={mfaCode}
-            onChange={e => setMfaCode(e.target.value.replace(/\D/g, ''))}
+            onChange={e => {
+                const sanitized = e.target.value.replace(/\D/g, '');
+                setMfaCode(sanitized);
+                clearValidationError('mfa');
+                setError(null);
+            }}
             maxLength={6}
             required
             inputMode="numeric"

--- a/components/UserRegistration.tsx
+++ b/components/UserRegistration.tsx
@@ -275,6 +275,19 @@ export const UserRegistration: React.FC<UserRegistrationProps> = ({ onSwitchToLo
         setGeneralError(authError);
     }, [authError]);
 
+    useEffect(() => {
+        if (emailStatus === 'available') {
+            setErrors(prev => {
+                if (!prev.email) {
+                    return prev;
+                }
+                const next = { ...prev };
+                delete next.email;
+                return next;
+            });
+        }
+    }, [emailStatus]);
+
     const companySelection = form.companySelection;
 
     useEffect(() => {
@@ -395,6 +408,8 @@ export const UserRegistration: React.FC<UserRegistrationProps> = ({ onSwitchToLo
                     nextErrors.email = 'Provide a valid work email address.';
                 } else if (emailStatus === 'unavailable') {
                     nextErrors.email = 'This email is already registered. Sign in instead.';
+                } else if (emailStatus === 'checking') {
+                    nextErrors.email = 'Hold on while we finish checking this email address.';
                 }
                 if (form.phone && !PHONE_REGEX.test(form.phone)) {
                     nextErrors.phone = 'Enter a valid phone number or leave this blank.';
@@ -461,6 +476,16 @@ export const UserRegistration: React.FC<UserRegistrationProps> = ({ onSwitchToLo
         return Object.keys(nextErrors).length === 0;
     };
 
+    const ensureAllStepsValid = (): boolean => {
+        for (const { id } of STEP_SEQUENCE) {
+            if (!validateStep(id)) {
+                setStep(id);
+                return false;
+            }
+        }
+        return true;
+    };
+
     const goToNextStep = () => {
         const currentIndex = STEP_SEQUENCE.findIndex(s => s.id === step);
         if (validateStep(step) && currentIndex < STEP_SEQUENCE.length - 1) {
@@ -476,7 +501,7 @@ export const UserRegistration: React.FC<UserRegistrationProps> = ({ onSwitchToLo
     };
 
     const handleSubmit = async () => {
-        if (!validateStep('confirm')) {
+        if (!ensureAllStepsValid()) {
             return;
         }
         setGeneralError(null);

--- a/components/UserRegistration.tsx
+++ b/components/UserRegistration.tsx
@@ -1,375 +1,828 @@
-import React, { useState, useEffect } from 'react';
-import { Role, Permission, RolePermissions, CompanyType, RegisterCredentials } from '../types';
-import { useAuth } from '../contexts/AuthContext';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Card } from './ui/Card';
 import { Button } from './ui/Button';
+import { useAuth } from '../contexts/AuthContext';
+import { authClient, InvitePreview } from '../services/authClient';
+import { CompanyType, RegistrationPayload, Role } from '../types';
+import { AuthEnvironmentNotice } from './auth/AuthEnvironmentNotice';
 
 interface UserRegistrationProps {
-  onSwitchToLogin: () => void;
+    onSwitchToLogin: () => void;
 }
 
-type Step = 'personal' | 'company' | 'role' | 'verify' | 'terms';
+type StepId = 'account' | 'workspace' | 'confirm';
 
-const STEPS: { id: Step; name: string }[] = [
-    { id: 'personal', name: 'Personal Info' },
-    { id: 'company', name: 'Company' },
-    { id: 'role', name: 'Your Role' },
-    { id: 'verify', name: 'Verification' },
-    { id: 'terms', name: 'Finish' },
+type FormErrors = Partial<Record<keyof RegistrationState, string>>;
+
+interface RegistrationState {
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone: string;
+    password: string;
+    confirmPassword: string;
+    companySelection: 'create' | 'join' | '';
+    companyName: string;
+    companyType: CompanyType | '';
+    companyEmail: string;
+    companyPhone: string;
+    companyWebsite: string;
+    inviteToken: string;
+    role: Role | '';
+    updatesOptIn: boolean;
+    termsAccepted: boolean;
+}
+
+const INITIAL_STATE: RegistrationState = {
+    firstName: '',
+    lastName: '',
+    email: '',
+    phone: '',
+    password: '',
+    confirmPassword: '',
+    companySelection: '',
+    companyName: '',
+    companyType: '',
+    companyEmail: '',
+    companyPhone: '',
+    companyWebsite: '',
+    inviteToken: '',
+    role: '',
+    updatesOptIn: true,
+    termsAccepted: false,
+};
+
+const STEP_SEQUENCE: { id: StepId; title: string; description: string }[] = [
+    { id: 'account', title: 'Account', description: 'Introduce yourself and secure access.' },
+    { id: 'workspace', title: 'Workspace', description: 'Create a company or join an existing team.' },
+    { id: 'confirm', title: 'Confirm', description: 'Review details and accept the terms.' },
 ];
 
-const PasswordStrengthIndicator: React.FC<{ password?: string }> = ({ password = '' }) => {
-    const getStrength = () => {
-        let score = 0;
-        if (password.length >= 8) score++;
-        if (/[A-Z]/.test(password)) score++;
-        if (/[a-z]/.test(password)) score++;
-        // FIX: Corrected regex to check for digits.
-        if (/\d/.test(password)) score++;
-        if (/[^A-Za-z0-9]/.test(password)) score++;
-        return score;
-    };
-    const strength = getStrength();
-    const width = (strength / 5) * 100;
-    const color = strength < 3 ? 'bg-destructive' : strength < 5 ? 'bg-yellow-500' : 'bg-green-500';
-
-    return (
-        <div className="w-full bg-muted rounded-full h-1.5 mt-1">
-            <div className={`h-1.5 rounded-full transition-all duration-300 ${color}`} style={{ width: `${width}%` }}></div>
-        </div>
-    );
+const STEP_FIELDS: Record<StepId, Array<keyof RegistrationState>> = {
+    account: ['firstName', 'lastName', 'email', 'phone', 'password', 'confirmPassword'],
+    workspace: ['companySelection', 'companyName', 'companyType', 'companyEmail', 'companyPhone', 'companyWebsite', 'inviteToken', 'role'],
+    confirm: ['termsAccepted'],
 };
 
-const CreateCompanyModal: React.FC<{
-    onClose: () => void;
-    onSave: (data: { name: string; type: CompanyType; email: string; phone: string; website: string; }) => void;
-    initialData: { name?: string; type?: CompanyType; email?: string; phone?: string; website?: string; };
-}> = ({ onClose, onSave, initialData }) => {
-    const [name, setName] = useState(initialData.name || '');
-    const [type, setType] = useState<CompanyType | ''>(initialData.type || '');
-    const [email, setEmail] = useState(initialData.email || '');
-    const [phone, setPhone] = useState(initialData.phone || '');
-    const [website, setWebsite] = useState(initialData.website || '');
-    const [errors, setErrors] = useState<Record<string, string>>({});
-    
-    const companyTypeOptions = [
-        { value: 'GENERAL_CONTRACTOR', label: 'General Contractor' },
-        { value: 'SUBCONTRACTOR', label: 'Subcontractor' },
-        { value: 'SUPPLIER', label: 'Supplier' },
-        { value: 'CONSULTANT', label: 'Consultant' },
-        { value: 'CLIENT', label: 'Client' },
+const COMPANY_TYPES: { value: CompanyType; label: string }[] = [
+    { value: 'GENERAL_CONTRACTOR', label: 'General Contractor' },
+    { value: 'SUBCONTRACTOR', label: 'Subcontractor' },
+    { value: 'SUPPLIER', label: 'Supplier' },
+    { value: 'CONSULTANT', label: 'Consultant' },
+    { value: 'CLIENT', label: 'Client' },
+];
+
+const ROLE_DETAILS: Record<Role, { label: string; description: string }> = {
+    [Role.OWNER]: {
+        label: 'Owner',
+        description: 'Full administrative access, billing controls, and user management.',
+    },
+    [Role.ADMIN]: {
+        label: 'Administrator',
+        description: 'Manage people, approvals, projects, and financial workflows.',
+    },
+    [Role.PROJECT_MANAGER]: {
+        label: 'Project Manager',
+        description: 'Coordinate schedules, tasks, stakeholders, and progress reporting.',
+    },
+    [Role.FOREMAN]: {
+        label: 'Foreman',
+        description: 'Lead on-site crews, raise safety issues, and track daily activity.',
+    },
+    [Role.OPERATIVE]: {
+        label: 'Operative',
+        description: 'Log time, update task progress, and collaborate with field teams.',
+    },
+    [Role.CLIENT]: {
+        label: 'Client',
+        description: 'Review milestones, approve work, and stay informed on delivery.',
+    },
+    [Role.PRINCIPAL_ADMIN]: {
+        label: 'Principal Admin',
+        description: 'Reserved for AS Agents platform administrators.',
+    },
+};
+
+const BENEFITS = [
+    'AI-assisted scheduling, forecasting, and risk insights for every project.',
+    'Role-based controls keep office teams and field crews perfectly aligned.',
+    'Secure document sharing, timesheets, and financial dashboards in one hub.',
+    'Offline-ready syncing so work continues even without a network connection.',
+];
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_REGEX = /^[+()\d\s-]{6,}$/;
+const URL_REGEX = /^https?:\/\/\S+$/i;
+
+const PasswordStrengthMeter: React.FC<{ password: string }> = ({ password }) => {
+    const rules = [
+        password.length >= 8,
+        /[A-Z]/.test(password),
+        /[a-z]/.test(password),
+        /\d/.test(password),
+        /[^A-Za-z0-9]/.test(password),
     ];
-
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault();
-        const newErrors: Record<string, string> = {};
-        if (!name.trim()) newErrors.name = "Company name is required.";
-        if (!type) newErrors.type = "Company type is required.";
-        if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) newErrors.email = "A valid company email is required.";
-        if (!phone.trim()) newErrors.phone = "Company phone number is required.";
-        
-        setErrors(newErrors);
-        
-        if (Object.keys(newErrors).length === 0) {
-            onSave({ name, type: type as CompanyType, email, phone, website });
-        }
-    };
+    const score = rules.filter(Boolean).length;
+    const width = (score / rules.length) * 100;
+    const color = score <= 2 ? 'bg-destructive' : score < 5 ? 'bg-amber-500' : 'bg-emerald-500';
+    const labels = ['Very weak', 'Weak', 'Fair', 'Strong', 'Excellent'];
 
     return (
-         <div className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4" onClick={onClose}>
-            <Card className="w-full max-w-lg" onClick={e => e.stopPropagation()}>
-                <h3 className="text-lg font-bold mb-4">Create Your Company</h3>
-                <form onSubmit={handleSubmit} className="space-y-4">
-                     <InputField label="Company Name" name="name" value={name} onChange={(_, val) => setName(val)} error={errors.name} />
-                     <SelectField label="Company Type" name="type" value={type} onChange={(_, val) => setType(val)} error={errors.type} options={companyTypeOptions}/>
-                     <InputField label="Company Email" name="email" type="email" value={email} onChange={(_, val) => setEmail(val)} error={errors.email} />
-                     <InputField label="Company Phone" name="phone" type="tel" value={phone} onChange={(_, val) => setPhone(val)} error={errors.phone} />
-                     <InputField label="Company Website (Optional)" name="website" type="url" value={website} onChange={(_, val) => setWebsite(val)} />
-                     <div className="flex justify-end gap-2 pt-4 border-t">
-                        <Button type="button" variant="secondary" onClick={onClose}>Cancel</Button>
-                        <Button type="submit">Save Company</Button>
-                    </div>
-                </form>
-            </Card>
+        <div className="space-y-1">
+            <div className="w-full h-1.5 rounded-full bg-muted">
+                <div className={`h-1.5 rounded-full transition-all duration-300 ${color}`} style={{ width: `${width}%` }} />
+            </div>
+            <p className="text-xs text-muted-foreground">
+                Password strength: <span className="font-medium text-foreground">{labels[Math.max(score - 1, 0)]}</span>
+            </p>
         </div>
     );
 };
+
+const StepIndicator: React.FC<{ currentStep: StepId }> = ({ currentStep }) => (
+    <ol className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        {STEP_SEQUENCE.map((step, index) => {
+            const isCompleted = STEP_SEQUENCE.findIndex(s => s.id === currentStep) > index;
+            const isActive = step.id === currentStep;
+            return (
+                <li key={step.id} className="flex flex-1 items-center gap-3">
+                    <div
+                        className={`flex h-9 w-9 items-center justify-center rounded-full border text-sm font-semibold transition-colors ${
+                            isCompleted
+                                ? 'border-primary bg-primary text-primary-foreground'
+                                : isActive
+                                    ? 'border-primary text-primary'
+                                    : 'border-border text-muted-foreground'
+                        }`}
+                    >
+                        {isCompleted ? '✓' : index + 1}
+                    </div>
+                    <div>
+                        <p className={`text-sm font-semibold ${isActive ? 'text-foreground' : 'text-muted-foreground'}`}>{step.title}</p>
+                        <p className="text-xs text-muted-foreground">{step.description}</p>
+                    </div>
+                </li>
+            );
+        })}
+    </ol>
+);
+
+interface TextFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    label: string;
+    error?: string;
+    hint?: string;
+}
+
+const TextField: React.FC<TextFieldProps> = ({ label, error, hint, className, id, ...props }) => (
+    <div className="space-y-1">
+        <label htmlFor={id} className="block text-sm font-medium text-muted-foreground">
+            {label}
+        </label>
+        <input
+            id={id}
+            className={`w-full rounded-md border px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary ${
+                error ? 'border-destructive' : 'border-border'
+            } ${className ?? ''}`}
+            {...props}
+        />
+        {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+        {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+);
+
+interface SelectFieldProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+    label: string;
+    options: { value: string; label: string }[];
+    error?: string;
+}
+
+const SelectField: React.FC<SelectFieldProps> = ({ label, options, error, id, className, ...props }) => (
+    <div className="space-y-1">
+        <label htmlFor={id} className="block text-sm font-medium text-muted-foreground">
+            {label}
+        </label>
+        <select
+            id={id}
+            className={`w-full rounded-md border px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary ${
+                error ? 'border-destructive' : 'border-border'
+            } ${className ?? ''}`}
+            {...props}
+        >
+            <option value="">Select…</option>
+            {options.map(option => (
+                <option key={option.value} value={option.value}>
+                    {option.label}
+                </option>
+            ))}
+        </select>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+);
+
+interface CheckboxFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    label: React.ReactNode;
+    description?: string;
+    error?: string;
+}
+
+const CheckboxField: React.FC<CheckboxFieldProps> = ({ label, description, error, ...props }) => (
+    <div className="space-y-1">
+        <label className="flex items-start gap-3 text-sm text-muted-foreground">
+            <input type="checkbox" className="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-primary" {...props} />
+            <span>
+                <span className="font-medium text-foreground">{label}</span>
+                {description && <span className="block text-xs text-muted-foreground">{description}</span>}
+            </span>
+        </label>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+);
+
+interface SelectionCardProps {
+    title: string;
+    description: string;
+    isSelected: boolean;
+    onSelect: () => void;
+}
+
+const SelectionCard: React.FC<SelectionCardProps> = ({ title, description, isSelected, onSelect }) => (
+    <button
+        type="button"
+        onClick={onSelect}
+        className={`rounded-lg border p-4 text-left transition focus:outline-none focus:ring-2 focus:ring-primary sm:p-5 ${
+            isSelected ? 'border-primary bg-primary/5 text-foreground shadow-sm' : 'border-border hover:border-primary'
+        }`}
+    >
+        <p className="text-sm font-semibold">{title}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+    </button>
+);
 
 export const UserRegistration: React.FC<UserRegistrationProps> = ({ onSwitchToLogin }) => {
-    const { register, error: authError, loading: isLoading } = useAuth();
-    const [step, setStep] = useState<Step>('personal');
-    const [formData, setFormData] = useState<Partial<RegisterCredentials & { companyName?: string; companyType?: CompanyType; companyEmail?: string; companyPhone?: string; companyWebsite?: string; companySelection?: 'create' | 'join', role?: Role, verificationCode?: string, termsAccepted?: boolean }>>({});
-    const [errors, setErrors] = useState<Record<string, string>>({});
+    const { register, error: authError, loading: isSubmitting } = useAuth();
+
+    const [step, setStep] = useState<StepId>('account');
+    const [form, setForm] = useState<RegistrationState>(INITIAL_STATE);
+    const [errors, setErrors] = useState<FormErrors>({});
     const [generalError, setGeneralError] = useState<string | null>(null);
-    const [isCompanyModalOpen, setIsCompanyModalOpen] = useState(false);
+
+    const [emailStatus, setEmailStatus] = useState<'idle' | 'checking' | 'available' | 'unavailable'>('idle');
+    const [invitePreview, setInvitePreview] = useState<InvitePreview | null>(null);
+    const [inviteError, setInviteError] = useState<string | null>(null);
+    const [isCheckingInvite, setIsCheckingInvite] = useState(false);
 
     useEffect(() => {
         setGeneralError(authError);
     }, [authError]);
 
-    const validateStep = (currentStep: Step): boolean => {
-        const newErrors: Record<string, string> = {};
+    const companySelection = form.companySelection;
+
+    useEffect(() => {
+        if (companySelection === 'create') {
+            setForm(prev => ({
+                ...prev,
+                role: Role.OWNER,
+                inviteToken: '',
+            }));
+            setInvitePreview(null);
+            setInviteError(null);
+            setErrors(prev => {
+                const next = { ...prev };
+                delete next.inviteToken;
+                delete next.role;
+                return next;
+            });
+        } else if (companySelection === 'join') {
+            setForm(prev => ({
+                ...prev,
+                role: prev.role && prev.role !== Role.OWNER ? prev.role : '',
+            }));
+        }
+    }, [companySelection]);
+
+    const allowedRoles = useMemo(() => {
+        if (companySelection === 'create') {
+            return [Role.OWNER];
+        }
+        if (companySelection === 'join' && invitePreview) {
+            return invitePreview.allowedRoles;
+        }
+        if (companySelection === 'join') {
+            return [];
+        }
+        return [Role.ADMIN, Role.PROJECT_MANAGER, Role.FOREMAN, Role.OPERATIVE];
+    }, [companySelection, invitePreview]);
+
+    const handleFieldChange = <K extends keyof RegistrationState>(field: K, value: RegistrationState[K]) => {
+        setForm(prev => ({ ...prev, [field]: value }));
+        setGeneralError(null);
+        setErrors(prev => {
+            if (!prev[field]) {
+                return prev;
+            }
+            const next = { ...prev };
+            delete next[field];
+            return next;
+        });
+
+        if (field === 'email') {
+            setEmailStatus('idle');
+        }
+        if (field === 'inviteToken') {
+            setInvitePreview(null);
+            setInviteError(null);
+        }
+    };
+
+    const handleEmailBlur = async () => {
+        const trimmed = form.email.trim();
+        if (!trimmed || !EMAIL_REGEX.test(trimmed)) {
+            return;
+        }
+        setEmailStatus('checking');
+        try {
+            const { available } = await authClient.checkEmailAvailability(trimmed);
+            setEmailStatus(available ? 'available' : 'unavailable');
+            if (!available) {
+                setErrors(prev => ({ ...prev, email: 'An account with this email already exists. Try signing in instead.' }));
+            }
+        } catch (error: any) {
+            setEmailStatus('idle');
+            setGeneralError(error?.message || 'Unable to verify email right now. Please try again later.');
+        }
+    };
+
+    const handleInviteLookup = async () => {
+        const token = form.inviteToken.trim();
+        if (!token) {
+            setErrors(prev => ({ ...prev, inviteToken: 'Enter the invite token provided to you.' }));
+            setInviteError('Invite token is required.');
+            return;
+        }
+        setIsCheckingInvite(true);
+        setInviteError(null);
+        try {
+            const preview = await authClient.lookupInviteToken(token);
+            setInvitePreview(preview);
+            setErrors(prev => {
+                const next = { ...prev };
+                delete next.inviteToken;
+                delete next.role;
+                return next;
+            });
+            if (!preview.allowedRoles.includes(form.role as Role)) {
+                handleFieldChange('role', preview.suggestedRole || preview.allowedRoles[0]);
+            }
+        } catch (error: any) {
+            setInvitePreview(null);
+            const message = error?.message || 'We could not validate that invite token. Please double-check and try again.';
+            setInviteError(message);
+            setErrors(prev => ({ ...prev, inviteToken: message }));
+        } finally {
+            setIsCheckingInvite(false);
+        }
+    };
+
+    const validateStep = (currentStep: StepId): boolean => {
+        const nextErrors: FormErrors = {};
+        const clearTargets = STEP_FIELDS[currentStep];
+
         switch (currentStep) {
-            case 'personal':
-                if (!formData.firstName || formData.firstName.length < 2) newErrors.firstName = "First name is required.";
-                if (!formData.lastName || formData.lastName.length < 2) newErrors.lastName = "Last name is required.";
-                if (!formData.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) newErrors.email = "A valid email is required.";
-                if (!formData.password || formData.password.length < 8) newErrors.password = "Password must be at least 8 characters.";
-                if (formData.password !== formData.confirmPassword) newErrors.confirmPassword = "Passwords do not match.";
-                break;
-            case 'company':
-                if (!formData.companySelection) newErrors.companySelection = "Please choose an option.";
-                else if (formData.companySelection === 'create' && (!formData.companyName || !formData.companyType)) {
-                    newErrors.companyName = "Company details are required. Please create or edit your company.";
-                } else if (formData.companySelection === 'join' && !formData.inviteToken) {
-                    newErrors.inviteToken = "An invite token is required.";
+            case 'account': {
+                if (!form.firstName.trim()) nextErrors.firstName = 'Enter your first name.';
+                if (!form.lastName.trim()) nextErrors.lastName = 'Enter your last name.';
+                if (!form.email.trim() || !EMAIL_REGEX.test(form.email)) {
+                    nextErrors.email = 'Provide a valid work email address.';
+                } else if (emailStatus === 'unavailable') {
+                    nextErrors.email = 'This email is already registered. Sign in instead.';
+                }
+                if (form.phone && !PHONE_REGEX.test(form.phone)) {
+                    nextErrors.phone = 'Enter a valid phone number or leave this blank.';
+                }
+                const password = form.password;
+                const requirements = [
+                    password.length >= 8,
+                    /[A-Z]/.test(password),
+                    /[a-z]/.test(password),
+                    /\d/.test(password),
+                    /[^A-Za-z0-9]/.test(password),
+                ];
+                if (!requirements.every(Boolean)) {
+                    nextErrors.password = 'Use at least 8 characters with upper/lower case letters, a number, and a symbol.';
+                }
+                if (password !== form.confirmPassword) {
+                    nextErrors.confirmPassword = 'Passwords must match exactly.';
                 }
                 break;
-            case 'role':
-                 if (!formData.role) newErrors.role = "Please select a role.";
+            }
+            case 'workspace': {
+                if (!form.companySelection) {
+                    nextErrors.companySelection = 'Choose whether to create a workspace or join an existing one.';
+                } else if (form.companySelection === 'create') {
+                    if (!form.companyName.trim()) nextErrors.companyName = 'Provide a company name.';
+                    if (!form.companyType) nextErrors.companyType = 'Select a company type.';
+                    if (form.companyEmail && !EMAIL_REGEX.test(form.companyEmail)) {
+                        nextErrors.companyEmail = 'Enter a valid email address or leave it blank.';
+                    }
+                    if (form.companyPhone && !PHONE_REGEX.test(form.companyPhone)) {
+                        nextErrors.companyPhone = 'Use digits and country code or leave this field empty.';
+                    }
+                    if (form.companyWebsite && !URL_REGEX.test(form.companyWebsite)) {
+                        nextErrors.companyWebsite = 'Include https:// in the company website URL.';
+                    }
+                } else if (form.companySelection === 'join') {
+                    if (!form.inviteToken.trim()) {
+                        nextErrors.inviteToken = 'Enter the invite token provided by your administrator.';
+                    } else if (!invitePreview) {
+                        nextErrors.inviteToken = 'Verify the invite token before continuing.';
+                    }
+                    if (!form.role) {
+                        nextErrors.role = 'Select the role you will assume in this workspace.';
+                    }
+                }
                 break;
-            case 'verify':
-                 if (formData.verificationCode !== '123456') newErrors.verificationCode = "Enter the mock code: 123456.";
+            }
+            case 'confirm': {
+                if (!form.termsAccepted) {
+                    nextErrors.termsAccepted = 'You must accept the terms of service to continue.';
+                }
                 break;
-            case 'terms':
-                if (!formData.termsAccepted) newErrors.termsAccepted = "You must accept the terms.";
-                break;
-        }
-        setErrors(newErrors);
-        return Object.keys(newErrors).length === 0;
-    };
-
-    const handleNext = () => {
-        if (validateStep(step)) {
-            const currentIndex = STEPS.findIndex(s => s.id === step);
-            if (currentIndex < STEPS.length - 1) {
-                setStep(STEPS[currentIndex + 1].id);
             }
         }
+
+        setErrors(prev => {
+            const cleaned = { ...prev };
+            clearTargets.forEach(field => {
+                delete cleaned[field];
+            });
+            return { ...cleaned, ...nextErrors };
+        });
+
+        return Object.keys(nextErrors).length === 0;
     };
 
-    const handleBack = () => {
-        const currentIndex = STEPS.findIndex(s => s.id === step);
+    const goToNextStep = () => {
+        const currentIndex = STEP_SEQUENCE.findIndex(s => s.id === step);
+        if (validateStep(step) && currentIndex < STEP_SEQUENCE.length - 1) {
+            setStep(STEP_SEQUENCE[currentIndex + 1].id);
+        }
+    };
+
+    const goToPreviousStep = () => {
+        const currentIndex = STEP_SEQUENCE.findIndex(s => s.id === step);
         if (currentIndex > 0) {
-            setStep(STEPS[currentIndex - 1].id);
-        }
-    };
-    
-    const handleChange = (field: keyof typeof formData, value: any) => {
-        if (field === 'companySelection' && value === 'create') {
-            setIsCompanyModalOpen(true);
-        }
-        setFormData(prev => ({ ...prev, [field]: value }));
-        if (errors[field]) {
-            setErrors(prev => {
-                const newErrors = { ...prev };
-                delete newErrors[field];
-                return newErrors;
-            });
+            setStep(STEP_SEQUENCE[currentIndex - 1].id);
         }
     };
 
-    const handleCompanySave = ({ name, type, email, phone, website }: { name: string; type: CompanyType; email: string; phone: string; website: string; }) => {
-        setFormData(prev => ({ ...prev, companyName: name, companyType: type, companyEmail: email, companyPhone: phone, companyWebsite: website, companySelection: 'create' }));
-        setIsCompanyModalOpen(false);
-        // Clear potential validation error after saving
-        if (errors.companyName) {
-            setErrors(prev => {
-                const newErrors = { ...prev };
-                delete newErrors.companyName;
-                return newErrors;
-            });
-        }
-    };
-    
     const handleSubmit = async () => {
-        if (!validateStep('terms')) return;
+        if (!validateStep('confirm')) {
+            return;
+        }
         setGeneralError(null);
+
+        const payload: RegistrationPayload = {
+            firstName: form.firstName.trim(),
+            lastName: form.lastName.trim(),
+            email: form.email.trim().toLowerCase(),
+            password: form.password,
+            phone: form.phone.trim() || undefined,
+            companySelection: form.companySelection || undefined,
+            companyName: form.companySelection === 'create' ? form.companyName.trim() : undefined,
+            companyType: form.companySelection === 'create' ? (form.companyType || undefined) : undefined,
+            companyEmail: form.companySelection === 'create' ? form.companyEmail.trim().toLowerCase() || undefined : undefined,
+            companyPhone: form.companySelection === 'create' ? form.companyPhone.trim() || undefined : undefined,
+            companyWebsite: form.companySelection === 'create' ? form.companyWebsite.trim() || undefined : undefined,
+            inviteToken: form.companySelection === 'join' ? form.inviteToken.trim() : undefined,
+            role: form.role || undefined,
+            updatesOptIn: form.updatesOptIn,
+            termsAccepted: form.termsAccepted,
+        };
+
         try {
-            await register(formData);
-            // On success, the AuthProvider will handle navigation.
-        } catch (error: any) {
-            // Error is handled by the context and set via useEffect
+            await register(payload);
+        } catch (error) {
+            // Errors are surfaced through auth context
         }
     };
 
-    const renderStepContent = () => {
+    const handleFormSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        if (step === 'confirm') {
+            handleSubmit();
+        } else {
+            goToNextStep();
+        }
+    };
+
+    const renderAccountStep = () => (
+        <div className="space-y-5">
+            <div className="grid gap-4 sm:grid-cols-2">
+                <TextField
+                    id="firstName"
+                    label="First name"
+                    value={form.firstName}
+                    onChange={event => handleFieldChange('firstName', event.target.value)}
+                    error={errors.firstName}
+                    autoComplete="given-name"
+                />
+                <TextField
+                    id="lastName"
+                    label="Last name"
+                    value={form.lastName}
+                    onChange={event => handleFieldChange('lastName', event.target.value)}
+                    error={errors.lastName}
+                    autoComplete="family-name"
+                />
+            </div>
+            <TextField
+                id="email"
+                label="Work email"
+                type="email"
+                value={form.email}
+                onChange={event => handleFieldChange('email', event.target.value)}
+                onBlur={handleEmailBlur}
+                error={errors.email}
+                autoComplete="email"
+                hint="We use this for secure login links and workspace notifications."
+            />
+            {emailStatus === 'checking' && <p className="text-xs text-muted-foreground">Checking email availability…</p>}
+            {emailStatus === 'available' && !errors.email && <p className="text-xs text-emerald-600">Great news — this email is available.</p>}
+            {emailStatus === 'unavailable' && <p className="text-xs text-destructive">This email is already registered. Try signing in instead.</p>}
+            <div className="grid gap-4 sm:grid-cols-2">
+                <TextField
+                    id="password"
+                    label="Password"
+                    type="password"
+                    value={form.password}
+                    onChange={event => handleFieldChange('password', event.target.value)}
+                    error={errors.password}
+                    autoComplete="new-password"
+                />
+                <TextField
+                    id="confirmPassword"
+                    label="Confirm password"
+                    type="password"
+                    value={form.confirmPassword}
+                    onChange={event => handleFieldChange('confirmPassword', event.target.value)}
+                    error={errors.confirmPassword}
+                    autoComplete="new-password"
+                />
+            </div>
+            <PasswordStrengthMeter password={form.password} />
+            <TextField
+                id="phone"
+                label="Phone number (optional)"
+                type="tel"
+                value={form.phone}
+                onChange={event => handleFieldChange('phone', event.target.value)}
+                error={errors.phone}
+                hint="Include country code if you want SMS reminders."
+            />
+        </div>
+    );
+
+    const renderWorkspaceStep = () => (
+        <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+                <SelectionCard
+                    title="Create a new workspace"
+                    description="Set up a workspace for your company and invite teammates later."
+                    isSelected={form.companySelection === 'create'}
+                    onSelect={() => handleFieldChange('companySelection', 'create')}
+                />
+                <SelectionCard
+                    title="Join an existing workspace"
+                    description="Use the invite token shared by an administrator to join instantly."
+                    isSelected={form.companySelection === 'join'}
+                    onSelect={() => handleFieldChange('companySelection', 'join')}
+                />
+            </div>
+            {errors.companySelection && <p className="text-xs text-destructive">{errors.companySelection}</p>}
+
+            {form.companySelection === 'create' && (
+                <div className="space-y-4">
+                    <TextField
+                        id="companyName"
+                        label="Company name"
+                        value={form.companyName}
+                        onChange={event => handleFieldChange('companyName', event.target.value)}
+                        error={errors.companyName}
+                        autoComplete="organization"
+                    />
+                    <SelectField
+                        id="companyType"
+                        label="Company type"
+                        value={form.companyType}
+                        onChange={event => handleFieldChange('companyType', event.target.value as CompanyType | '')}
+                        options={COMPANY_TYPES}
+                        error={errors.companyType}
+                    />
+                    <TextField
+                        id="companyEmail"
+                        label="Company email (optional)"
+                        type="email"
+                        value={form.companyEmail}
+                        onChange={event => handleFieldChange('companyEmail', event.target.value)}
+                        error={errors.companyEmail}
+                    />
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <TextField
+                            id="companyPhone"
+                            label="Company phone (optional)"
+                            value={form.companyPhone}
+                            onChange={event => handleFieldChange('companyPhone', event.target.value)}
+                            error={errors.companyPhone}
+                        />
+                        <TextField
+                            id="companyWebsite"
+                            label="Company website (optional)"
+                            placeholder="https://example.com"
+                            value={form.companyWebsite}
+                            onChange={event => handleFieldChange('companyWebsite', event.target.value)}
+                            error={errors.companyWebsite}
+                        />
+                    </div>
+                    <div className="rounded-md border border-dashed border-primary/50 bg-primary/5 p-4 text-xs text-muted-foreground">
+                        You will be registered as the workspace owner with full administrative access. Invite additional team members after onboarding.
+                    </div>
+                </div>
+            )}
+
+            {form.companySelection === 'join' && (
+                <div className="space-y-4">
+                    <div className="space-y-2">
+                        <label htmlFor="inviteToken" className="block text-sm font-medium text-muted-foreground">
+                            Invite token
+                        </label>
+                        <div className="flex flex-col gap-2 sm:flex-row">
+                            <input
+                                id="inviteToken"
+                                className={`flex-1 rounded-md border px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary ${
+                                    errors.inviteToken ? 'border-destructive' : 'border-border'
+                                }`}
+                                value={form.inviteToken}
+                                onChange={event => handleFieldChange('inviteToken', event.target.value.toUpperCase())}
+                                placeholder="JOIN-XXXXX"
+                            />
+                            <Button type="button" onClick={handleInviteLookup} isLoading={isCheckingInvite} variant="secondary" size="sm">
+                                Verify token
+                            </Button>
+                        </div>
+                        {inviteError && <p className="text-xs text-destructive">{inviteError}</p>}
+                        {invitePreview && (
+                            <div className="rounded-md border border-primary/40 bg-primary/5 p-3 text-xs text-muted-foreground">
+                                <p className="font-medium text-foreground">Joining: {invitePreview.companyName}</p>
+                                {invitePreview.companyType && <p className="mt-1">Type: {invitePreview.companyType.replace(/_/g, ' ').toLowerCase()}</p>}
+                                <p className="mt-1">Allowed roles: {invitePreview.allowedRoles.map(role => ROLE_DETAILS[role].label).join(', ')}</p>
+                            </div>
+                        )}
+                        {errors.inviteToken && <p className="text-xs text-destructive">{errors.inviteToken}</p>}
+                    </div>
+                    <SelectField
+                        id="role"
+                        label="Select your role"
+                        value={form.role || ''}
+                        onChange={event => handleFieldChange('role', (event.target.value as Role) || '')}
+                        options={allowedRoles.map(role => ({ value: role, label: ROLE_DETAILS[role].label }))}
+                        error={errors.role}
+                        disabled={!invitePreview}
+                    />
+                    {form.role && (
+                        <div className="rounded-md border border-border bg-muted/20 p-3 text-xs text-muted-foreground">
+                            <p className="font-medium text-foreground">{ROLE_DETAILS[form.role].label}</p>
+                            <p className="mt-1 leading-relaxed">{ROLE_DETAILS[form.role].description}</p>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+
+    const renderConfirmStep = () => (
+        <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+                <Card className="p-4">
+                    <p className="text-sm font-semibold text-foreground">Account</p>
+                    <dl className="mt-2 space-y-1 text-xs text-muted-foreground">
+                        <div className="flex justify-between"><dt>Name</dt><dd className="text-right text-foreground">{form.firstName} {form.lastName}</dd></div>
+                        <div className="flex justify-between"><dt>Email</dt><dd className="text-right text-foreground">{form.email}</dd></div>
+                        {form.phone && <div className="flex justify-between"><dt>Phone</dt><dd className="text-right text-foreground">{form.phone}</dd></div>}
+                    </dl>
+                </Card>
+                <Card className="p-4">
+                    <p className="text-sm font-semibold text-foreground">Workspace</p>
+                    <dl className="mt-2 space-y-1 text-xs text-muted-foreground">
+                        <div className="flex justify-between"><dt>Mode</dt><dd className="text-right text-foreground">{form.companySelection === 'create' ? 'Creating new workspace' : 'Joining existing workspace'}</dd></div>
+                        {form.companySelection === 'create' && (
+                            <>
+                                <div className="flex justify-between"><dt>Company</dt><dd className="text-right text-foreground">{form.companyName}</dd></div>
+                                {form.companyType && <div className="flex justify-between"><dt>Type</dt><dd className="text-right text-foreground">{form.companyType.replace(/_/g, ' ').toLowerCase()}</dd></div>}
+                            </>
+                        )}
+                        {form.companySelection === 'join' && invitePreview && (
+                            <>
+                                <div className="flex justify-between"><dt>Company</dt><dd className="text-right text-foreground">{invitePreview.companyName}</dd></div>
+                                <div className="flex justify-between"><dt>Role</dt><dd className="text-right text-foreground">{form.role ? ROLE_DETAILS[form.role].label : 'Pending selection'}</dd></div>
+                            </>
+                        )}
+                    </dl>
+                </Card>
+            </div>
+            <CheckboxField
+                checked={form.updatesOptIn}
+                onChange={event => handleFieldChange('updatesOptIn', event.target.checked)}
+                label="Keep me updated with product improvements and release notes"
+            />
+            <CheckboxField
+                checked={form.termsAccepted}
+                onChange={event => handleFieldChange('termsAccepted', event.target.checked)}
+                label="I agree to the AS Agents Terms of Service"
+                description="You acknowledge our Privacy Policy and accept the responsibilities associated with holding project data."
+                error={errors.termsAccepted}
+            />
+        </div>
+    );
+
+    const currentStepContent = () => {
         switch (step) {
-            case 'personal': return (
-                <>
-                    <div className="grid grid-cols-2 gap-4">
-                        <InputField label="First Name" name="firstName" value={formData.firstName || ''} onChange={handleChange} error={errors.firstName} />
-                        <InputField label="Last Name" name="lastName" value={formData.lastName || ''} onChange={handleChange} error={errors.lastName} />
-                    </div>
-                    <InputField label="Email" name="email" type="email" value={formData.email || ''} onChange={handleChange} error={errors.email} />
-                    <InputField label="Phone (Optional)" name="phone" type="tel" value={formData.phone || ''} onChange={handleChange} error={errors.phone} />
-                    <InputField label="Password" name="password" type="password" value={formData.password || ''} onChange={handleChange} error={errors.password} />
-                    <PasswordStrengthIndicator password={formData.password} />
-                    <InputField label="Confirm Password" name="confirmPassword" type="password" value={formData.confirmPassword || ''} onChange={handleChange} error={errors.confirmPassword} />
-                </>
-            );
-            case 'company': return (
-                <>
-                   <div className="space-y-2">
-                        <RadioCard name="companySelection" value="create" label="Create a new company" description="Set up a new workspace for your team." checked={formData.companySelection === 'create'} onChange={handleChange} />
-                        <RadioCard name="companySelection" value="join" label="Join an existing company" description="You'll need an invite token from the company." checked={formData.companySelection === 'join'} onChange={handleChange} />
-                        {errors.companySelection && <p className="text-xs text-destructive mt-1">{errors.companySelection}</p>}
-                    </div>
-                    {formData.companySelection === 'create' && formData.companyName && (
-                        <Card className="mt-4 bg-muted animate-card-enter">
-                           <div className="flex justify-between items-start">
-                                <div>
-                                    <p className="font-semibold">{formData.companyName}</p>
-                                    <p className="text-sm text-muted-foreground">{formData.companyType?.replace(/_/g, ' ')}</p>
-                                    <p className="text-sm text-muted-foreground">{formData.companyEmail}</p>
-                                    <p className="text-sm text-muted-foreground">{formData.companyPhone}</p>
-                                    {formData.companyWebsite && <p className="text-sm text-muted-foreground">{formData.companyWebsite}</p>}
-                                </div>
-                                <Button variant="secondary" size="sm" onClick={() => setIsCompanyModalOpen(true)}>Edit</Button>
-                           </div>
-                        </Card>
-                    )}
-                    {errors.companyName && <p className="text-xs text-destructive mt-1">{errors.companyName}</p>}
-                     {formData.companySelection === 'join' && (
-                        <Card className="mt-4 bg-muted animate-card-enter">
-                             <InputField label="Company Invite Token" name="inviteToken" value={formData.inviteToken || ''} onChange={handleChange} error={errors.inviteToken} placeholder="Enter the token provided to you" />
-                        </Card>
-                    )}
-                </>
-            );
-            case 'role':
-                const selectedRolePermissions = formData.role ? RolePermissions[formData.role] : new Set();
-                return (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                         <div className="space-y-2">
-                             {[Role.PROJECT_MANAGER, Role.FOREMAN, Role.OPERATIVE].map(role => (
-                                <RadioCard key={role} name="role" value={role} label={role.replace(/_/g, ' ')} description="" checked={formData.role === role} onChange={handleChange} />
-                            ))}
-                            {errors.role && <p className="text-xs text-destructive mt-1">{errors.role}</p>}
-                         </div>
-                         <Card className="bg-muted">
-                            <h4 className="font-semibold mb-2">Role Permissions Preview</h4>
-                            {formData.role ? (
-                                <ul className="text-sm space-y-1 list-disc list-inside max-h-60 overflow-y-auto">
-                                    {Array.from(selectedRolePermissions).map(p => <li key={p as string} className="capitalize">{String(p).replace(/_/g, ' ').toLowerCase()}</li>)}
-                                </ul>
-                            ) : <p className="text-sm text-muted-foreground">Select a role to see its permissions.</p>}
-                         </Card>
-                    </div>
-                );
-            case 'verify': return (
-                <div className="text-center">
-                    <h3 className="font-semibold">Verify Your Email</h3>
-                    <p className="text-muted-foreground text-sm mt-1 mb-4">We've "sent" a 6-digit code to {formData.email}. For this demo, please enter <strong>123456</strong>.</p>
-                     <InputField label="Verification Code" name="verificationCode" value={formData.verificationCode || ''} onChange={(name: string, val: string) => handleChange(name as keyof typeof formData, val.replace(/\D/g, ''))} error={errors.verificationCode} maxLength={6} inputClassName="text-center tracking-[0.5em] text-2xl" isLabelSrOnly />
-                </div>
-            );
-            case 'terms': return (
-                <div>
-                     <div className="flex items-start">
-                        <input id="terms" type="checkbox" checked={!!formData.termsAccepted} onChange={e => handleChange('termsAccepted', e.target.checked)} className="h-4 w-4 text-primary focus:ring-ring border-border rounded mt-1"/>
-                        <label htmlFor="terms" className="ml-2 block text-sm text-muted-foreground">I agree to the <a href="#" className="font-medium text-primary hover:text-primary/90">Terms and Conditions</a> and <a href="#" className="font-medium text-primary hover:text-primary/90">Privacy Policy</a>.</label>
-                    </div>
-                    {errors.termsAccepted && <p className="text-xs text-destructive mt-1">{errors.termsAccepted}</p>}
-                </div>
-            );
-            default: return null;
+            case 'account':
+                return renderAccountStep();
+            case 'workspace':
+                return renderWorkspaceStep();
+            case 'confirm':
+                return renderConfirmStep();
+            default:
+                return null;
         }
     };
-
-    const currentStepIndex = STEPS.findIndex(s => s.id === step);
 
     return (
-        <>
-            {isCompanyModalOpen && (
-                <CreateCompanyModal 
-                    onClose={() => setIsCompanyModalOpen(false)} 
-                    onSave={handleCompanySave}
-                    initialData={{ name: formData.companyName, type: formData.companyType, email: formData.companyEmail, phone: formData.companyPhone, website: formData.companyWebsite }}
-                />
-            )}
-            <div className="min-h-screen bg-background flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-                <div className="sm:mx-auto sm:w-full sm:max-w-3xl">
-                    <div className="text-center mb-8">
-                        <div className="inline-flex items-center justify-center gap-2 mb-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="w-10 h-10 text-primary"><path fill="currentColor" d="M12 2L2 22h20L12 2z"/></svg>
-                            <h1 className="text-3xl font-bold text-foreground">AS Agents</h1>
+        <div className="min-h-screen bg-background py-10 px-4">
+            <div className="mx-auto grid w-full max-w-5xl gap-10 lg:grid-cols-[2fr,1fr]">
+                <div className="space-y-6">
+                    <div className="space-y-2">
+                        <div className="inline-flex items-center gap-2">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-8 w-8 text-primary" fill="currentColor">
+                                <path d="M12 2 2 22h20L12 2Zm0 3.3L19.1 20H4.9L12 5.3Z" />
+                            </svg>
+                            <h1 className="text-2xl font-bold text-foreground">Create your AS Agents account</h1>
                         </div>
-                        <h2 className="text-muted-foreground">Create your account</h2>
+                        <p className="text-sm text-muted-foreground">Three quick steps to get your construction teams collaborating in one workspace.</p>
                     </div>
 
-                    <div className="mb-8 px-4">
-                        <div className="flex items-center">
-                            {STEPS.map((s, index) => (
-                                <React.Fragment key={s.id}>
-                                    <div className="flex flex-col items-center">
-                                        <div className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${index <= currentStepIndex ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}>
-                                            {index < currentStepIndex ? '✓' : index + 1}
-                                        </div>
-                                        <p className={`text-xs mt-1 text-center ${index <= currentStepIndex ? 'font-semibold text-primary' : 'text-muted-foreground'}`}>{s.name}</p>
-                                    </div>
-                                    {index < STEPS.length - 1 && <div className={`flex-grow h-0.5 transition-colors ${index < currentStepIndex ? 'bg-primary' : 'bg-muted'}`}></div>}
-                                </React.Fragment>
-                            ))}
+                    <StepIndicator currentStep={step} />
+
+                    {generalError && (
+                        <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+                            {generalError}
                         </div>
-                    </div>
+                    )}
 
                     <Card>
-                        {generalError && <div className="mb-4 p-3 bg-destructive/10 text-destructive text-sm rounded-md">{generalError}</div>}
-                        <div className="space-y-6">
-                            {renderStepContent()}
-                        </div>
-                        <div className="mt-8 flex justify-between items-center">
-                            {step !== 'personal' ? (
-                                <Button variant="secondary" onClick={handleBack}>Back</Button>
-                            ) : <div></div>}
-                            
-                            {step === 'terms' ? (
-                                <Button onClick={handleSubmit} isLoading={isLoading} disabled={!formData.termsAccepted}>Complete Registration</Button>
-                            ) : (
-                                <Button onClick={handleNext}>Next</Button>
-                            )}
-                        </div>
+                        <form className="space-y-6" onSubmit={handleFormSubmit} noValidate>
+                            <AuthEnvironmentNotice align="left" className="rounded-md bg-muted/40 px-3 py-2" />
+                            {currentStepContent()}
+                            <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row sm:items-center sm:justify-between">
+                                <div className="flex items-center gap-3">
+                                    {step !== 'account' ? (
+                                        <Button type="button" variant="secondary" onClick={goToPreviousStep}>
+                                            Back
+                                        </Button>
+                                    ) : (
+                                        <button type="button" onClick={onSwitchToLogin} className="text-sm font-medium text-primary hover:text-primary/80">
+                                            Already have an account? Sign in
+                                        </button>
+                                    )}
+                                </div>
+                                <Button type="submit" isLoading={isSubmitting}>
+                                    {step === 'confirm' ? 'Create account' : 'Continue'}
+                                </Button>
+                            </div>
+                        </form>
                     </Card>
-                    <p className="mt-6 text-center text-sm text-muted-foreground">
-                        Already have an account?{' '}
-                        <button onClick={onSwitchToLogin} className="font-semibold text-primary hover:text-primary/80">
-                            Sign in
-                        </button>
-                    </p>
                 </div>
+
+                <Card className="space-y-5 bg-muted/40">
+                    <div>
+                        <p className="text-sm font-semibold text-foreground">Why teams choose AS Agents</p>
+                        <ul className="mt-3 space-y-2 text-xs text-muted-foreground">
+                            {BENEFITS.map(benefit => (
+                                <li key={benefit} className="flex items-start gap-2">
+                                    <span className="mt-0.5 text-primary">•</span>
+                                    <span>{benefit}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                    <div className="rounded-md border border-border bg-background p-4 text-xs text-muted-foreground">
+                        <p className="font-medium text-foreground">Need to invite your crew?</p>
+                        <p className="mt-1 leading-relaxed">
+                            Owners can add teammates instantly after onboarding. Prefer us to help? Reach out and we’ll migrate existing project data for you.
+                        </p>
+                    </div>
+                </Card>
             </div>
-        </>
+        </div>
     );
 };
-
-
-// --- Form Field Components ---
-const InputField = ({ label, name, type = 'text', value = '', onChange, error, maxLength, inputClassName = '', isLabelSrOnly = false, placeholder }: { label: string; name: string; type?: string; value?: string; onChange: (name: string, value: string) => void; error?: string; maxLength?: number; inputClassName?: string; isLabelSrOnly?: boolean; placeholder?: string }) => (
-    <div>
-        <label htmlFor={name} className={isLabelSrOnly ? 'sr-only' : 'block text-sm font-medium text-muted-foreground'}>{label}</label>
-        <input id={name} name={name} type={type} value={value} maxLength={maxLength} onChange={e => onChange(name, e.target.value)} placeholder={placeholder}
-                className={`mt-1 block w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm ${error ? 'border-destructive' : 'border-border'} ${inputClassName}`} />
-        {error && <p className="text-xs text-destructive mt-1">{error}</p>}
-    </div>
-);
-
-const SelectField = ({ label, name, value, onChange, error, options }: {label: string, name: string, value: any, onChange: any, error?: string, options: {value:string, label:string}[]}) => (
-    <div>
-        <label htmlFor={name} className="block text-sm font-medium text-muted-foreground">{label}</label>
-        <select id={name} name={name} value={value} onChange={e => onChange(name, e.target.value)} required
-                className={`mt-1 block w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm bg-card ${error ? 'border-destructive' : 'border-border'}`}>
-            <option value="">Select an option</option>
-            {options.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-        </select>
-        {error && <p className="text-xs text-destructive mt-1">{error}</p>}
-    </div>
-);
-
-const RadioCard = ({ name, value, label, description, checked, onChange }: { name: string, value: string | CompanyType | Role, label: string, description: string, checked: boolean, onChange: any }) => (
-    <label className={`block p-4 border rounded-md cursor-pointer transition-all ${checked ? 'bg-primary/10 border-primary ring-2 ring-primary' : 'hover:bg-accent'}`}>
-        <input type="radio" name={name} value={value} checked={checked} onChange={e => onChange(name, e.target.value)} className="sr-only"/>
-        <p className="font-semibold">{label}</p>
-        {description && <p className="text-sm text-muted-foreground">{description}</p>}
-    </label>
-);

--- a/components/auth/AuthEnvironmentNotice.tsx
+++ b/components/auth/AuthEnvironmentNotice.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
-import { getAuthConnectionInfo } from '../../services/authClient';
+import React, { useMemo, useSyncExternalStore } from 'react';
+import { getAuthConnectionInfo, subscribeToAuthClientChanges, type AuthConnectionInfo } from '../../services/authClient';
 
 interface AuthEnvironmentNoticeProps {
     align?: 'left' | 'center';
     className?: string;
 }
 
-const formatMessage = () => {
-    const info = getAuthConnectionInfo();
+const useAuthConnectionInfo = () =>
+    useSyncExternalStore(subscribeToAuthClientChanges, getAuthConnectionInfo, getAuthConnectionInfo);
+
+const formatMessage = (info: AuthConnectionInfo) => {
     if (info.mode === 'backend') {
         const host = info.baseHost || info.baseUrl || 'configured backend';
         const fallbackNote = info.allowMockFallback
@@ -19,7 +21,11 @@ const formatMessage = () => {
 };
 
 export const AuthEnvironmentNotice: React.FC<AuthEnvironmentNoticeProps> = ({ align = 'center', className = '' }) => {
-    const message = React.useMemo(() => formatMessage(), []);
+    const info = useAuthConnectionInfo();
+    const message = useMemo(
+        () => formatMessage(info),
+        [info.mode, info.baseHost, info.baseUrl, info.allowMockFallback]
+    );
     const alignmentClass = align === 'left' ? 'text-left' : 'text-center';
     return (
         <p className={`text-xs text-muted-foreground ${alignmentClass} ${className}`.trim()}>{message}</p>

--- a/components/auth/AuthEnvironmentNotice.tsx
+++ b/components/auth/AuthEnvironmentNotice.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { getAuthConnectionInfo } from '../../services/authClient';
+
+interface AuthEnvironmentNoticeProps {
+    align?: 'left' | 'center';
+    className?: string;
+}
+
+const formatMessage = () => {
+    const info = getAuthConnectionInfo();
+    if (info.mode === 'backend') {
+        const host = info.baseHost || info.baseUrl || 'configured backend';
+        const fallbackNote = info.allowMockFallback
+            ? ' If the service cannot be reached we will seamlessly fall back to the local demo store.'
+            : '';
+        return `Authenticated against ${host}.${fallbackNote}`;
+    }
+    return 'Operating in secure offline demo mode. Accounts are stored locally in your browser.';
+};
+
+export const AuthEnvironmentNotice: React.FC<AuthEnvironmentNoticeProps> = ({ align = 'center', className = '' }) => {
+    const message = React.useMemo(() => formatMessage(), []);
+    const alignmentClass = align === 'left' ? 'text-left' : 'text-center';
+    return (
+        <p className={`text-xs text-muted-foreground ${alignmentClass} ${className}`.trim()}>{message}</p>
+    );
+};
+

--- a/components/auth/ForgotPassword.tsx
+++ b/components/auth/ForgotPassword.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
+import { AuthEnvironmentNotice } from './AuthEnvironmentNotice';
 
 interface ForgotPasswordProps {
   onSwitchToLogin: () => void;
@@ -47,6 +48,7 @@ export const ForgotPassword: React.FC<ForgotPasswordProps> = ({ onSwitchToLogin 
                 </p>
             </div>
             <Card className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+                <AuthEnvironmentNotice className="mb-4" />
                 {authError && <div className="mb-4 p-3 bg-destructive/10 text-destructive text-sm rounded-md">{authError}</div>}
                 {error && <div className="mb-4 p-3 bg-destructive/10 text-destructive text-sm rounded-md">{error}</div>}
                 {successMessage ? (

--- a/components/auth/ResetPassword.tsx
+++ b/components/auth/ResetPassword.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
+import { AuthEnvironmentNotice } from './AuthEnvironmentNotice';
 
 interface ResetPasswordProps {
   token: string;
@@ -75,6 +76,7 @@ export const ResetPassword: React.FC<ResetPasswordProps> = ({ token, onSuccess }
         return (
              <div className="min-h-screen bg-background flex flex-col justify-center py-12 sm:px-6 lg:px-8">
                 <Card className="sm:mx-auto sm:w-full sm:max-w-md text-center">
+                    <AuthEnvironmentNotice className="mb-4" />
                     <h2 className="text-2xl font-bold text-foreground mb-4">Password Reset Successfully!</h2>
                     <p className="text-muted-foreground mb-6">You can now sign in with your new password.</p>
                     <Button onClick={onSuccess} className="w-full">Back to Sign In</Button>
@@ -92,6 +94,7 @@ export const ResetPassword: React.FC<ResetPasswordProps> = ({ token, onSuccess }
                 </p>
             </div>
             <Card className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+                 <AuthEnvironmentNotice className="mb-4" />
                  {error && <div className="mb-4 p-3 bg-destructive/10 text-destructive text-sm rounded-md">{error}</div>}
                 <form onSubmit={handleSubmit} className="space-y-6">
                     <InputField label="New Password" name="password" type="password" value={password} onChange={(_, val) => setPassword(val)} />

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,12 +1,15 @@
 import React, { createContext, useState, useContext, useEffect, useCallback, ReactNode } from 'react';
-import { User, Company, LoginCredentials, RegisterCredentials, AuthState, Permission } from '../types';
-import { authApi } from '../services/mockApi';
+import { User, Company, LoginCredentials, RegistrationPayload, AuthState, Permission } from '../types';
+import { authClient } from '../services/authClient';
 import { hasPermission as checkPermission } from '../services/auth';
 import { api } from '../services/mockApi';
+import { getStorage } from '../utils/storage';
+
+const storage = getStorage();
 
 interface AuthContextType extends AuthState {
     login: (credentials: LoginCredentials) => Promise<{ mfaRequired: boolean; userId?: string }>;
-    register: (credentials: Partial<RegisterCredentials>) => Promise<void>;
+    register: (credentials: RegistrationPayload) => Promise<void>;
     logout: () => void;
     hasPermission: (permission: Permission) => boolean;
     verifyMfaAndFinalize: (userId: string, code: string) => Promise<void>;
@@ -39,8 +42,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     });
 
     const logout = useCallback(() => {
-        localStorage.removeItem('token');
-        localStorage.removeItem('refreshToken');
+        storage.removeItem('token');
+        storage.removeItem('refreshToken');
         if (tokenRefreshTimeout) clearTimeout(tokenRefreshTimeout);
         setAuthState({
             isAuthenticated: false,
@@ -67,12 +70,12 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             const expiresIn = (decoded.exp * 1000) - Date.now() - 60000;
             if (expiresIn > 0) {
                 tokenRefreshTimeout = setTimeout(async () => {
-                    const storedRefreshToken = localStorage.getItem('refreshToken');
+                    const storedRefreshToken = storage.getItem('refreshToken');
                     if (storedRefreshToken) {
                         try {
                             console.log("Proactively refreshing token...");
-                            const { token: newToken } = await authApi.refreshToken(storedRefreshToken);
-                            localStorage.setItem('token', newToken);
+                            const { token: newToken } = await authClient.refreshToken(storedRefreshToken);
+                            storage.setItem('token', newToken);
                             setAuthState(prev => ({ ...prev, token: newToken }));
                             scheduleTokenRefresh(newToken); // Schedule the next refresh
                         } catch (error) {
@@ -90,8 +93,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }, [logout]);
     
     const finalizeLogin = useCallback((data: { token: string, refreshToken: string, user: User, company: Company }) => {
-        localStorage.setItem('token', data.token);
-        localStorage.setItem('refreshToken', data.refreshToken);
+        storage.setItem('token', data.token);
+        storage.setItem('refreshToken', data.refreshToken);
         setAuthState({
             isAuthenticated: true,
             token: data.token,
@@ -110,19 +113,19 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
      * If the access token is expired, it reactively tries to use the refresh token.
      */
     const initAuth = useCallback(async () => {
-        const token = localStorage.getItem('token');
-        const refreshToken = localStorage.getItem('refreshToken');
+        const token = storage.getItem('token');
+        const refreshToken = storage.getItem('refreshToken');
         if (token && refreshToken) {
             try {
                 // First, try to authenticate with the existing access token.
-                const { user, company } = await authApi.me(token);
+                const { user, company } = await authClient.me(token);
                 finalizeLogin({ token, refreshToken, user, company });
             } catch (error) {
                 // If authApi.me fails (e.g., token expired), attempt to refresh the token.
                 console.log("Access token invalid, attempting reactive refresh...");
                 try {
-                    const { token: newToken } = await authApi.refreshToken(refreshToken);
-                    const { user, company } = await authApi.me(newToken);
+                    const { token: newToken } = await authClient.refreshToken(refreshToken);
+                    const { user, company } = await authClient.me(newToken);
                     finalizeLogin({ token: newToken, refreshToken, user, company });
                 } catch (refreshError) {
                     console.error("Auth init with refresh token failed, logging out.", refreshError);
@@ -144,7 +147,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     const login = async (credentials: LoginCredentials): Promise<{ mfaRequired: boolean; userId?: string }> => {
         setAuthState(prev => ({ ...prev, loading: true, error: null }));
         try {
-            const response = await authApi.login(credentials);
+            const response = await authClient.login(credentials);
             if (response.mfaRequired) {
                 setAuthState(prev => ({ ...prev, loading: false }));
                 return { mfaRequired: true, userId: response.userId };
@@ -162,7 +165,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     const verifyMfaAndFinalize = async (userId: string, code: string) => {
         setAuthState(prev => ({ ...prev, loading: true, error: null }));
          try {
-            const response = await authApi.verifyMfa(userId, code);
+            const response = await authClient.verifyMfa(userId, code);
             finalizeLogin(response);
         } catch (error: any) {
             setAuthState(prev => ({ ...prev, loading: false, error: error.message || 'MFA verification failed'}));
@@ -170,10 +173,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         }
     }
 
-    const register = async (credentials: Partial<RegisterCredentials>) => {
+    const register = async (credentials: RegistrationPayload) => {
         setAuthState(prev => ({ ...prev, loading: true, error: null }));
         try {
-            const response = await authApi.register(credentials);
+            const response = await authClient.register(credentials);
             finalizeLogin(response);
         } catch (error: any) {
              setAuthState(prev => ({ ...prev, loading: false, error: error.message || 'Registration failed'}));
@@ -198,7 +201,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     const requestPasswordReset = async (email: string) => {
         setAuthState(prev => ({ ...prev, loading: true, error: null }));
         try {
-            await authApi.requestPasswordReset(email);
+            await authClient.requestPasswordReset(email);
             setAuthState(prev => ({ ...prev, loading: false }));
         } catch (error: any) {
             setAuthState(prev => ({ ...prev, loading: false, error: error.message || 'Request failed'}));
@@ -209,7 +212,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     const resetPassword = async (token: string, newPassword: string) => {
         setAuthState(prev => ({ ...prev, loading: true, error: null }));
         try {
-            await authApi.resetPassword(token, newPassword);
+            await authClient.resetPassword(token, newPassword);
             setAuthState(prev => ({ ...prev, loading: false }));
         } catch (error: any) {
             setAuthState(prev => ({ ...prev, loading: false, error: error.message || 'Password reset failed'}));

--- a/docs/deployment-log.md
+++ b/docs/deployment-log.md
@@ -2,6 +2,14 @@
 
 This log captures each run of the autonomous deployment plan in the local container environment.
 
+## 2025-09-20 (Run 3)
+
+| Step | Command | Result | Notes |
+|------|---------|--------|-------|
+| 1 | `npm ci` | ✅ Success | Clean reinstall completed in 4s; npm reported 5 moderate advisories to monitor. |
+| 2 | `npx vitest run --reporter=basic` | ✅ Success | All 22 Vitest suites passed; auth client fallback emitted expected ECONNREFUSED warning. |
+| 3 | `GEMINI_API_KEY=test VITE_GEMINI_API_KEY=test npm run build` | ✅ Success | Production bundle built in 3.6s; Rollup chunk-size warning persists and is tracked. |
+
 ## 2025-09-20 (Run 2)
 
 | Step | Command | Result | Notes |

--- a/docs/deployment-log.md
+++ b/docs/deployment-log.md
@@ -2,6 +2,14 @@
 
 This log captures each run of the autonomous deployment plan in the local container environment.
 
+## 2025-09-20 (Run 2)
+
+| Step | Command | Result | Notes |
+|------|---------|--------|-------|
+| 1 | `npm ci` | ✅ Success | Reinstalled dependencies; npm reported 5 moderate advisories to monitor. |
+| 2 | `npm run test -- --run` | ✅ Success | Vitest suites for auth client/API, finance helpers, and registration draft passed using fresh installs. |
+| 3 | `GEMINI_API_KEY=test VITE_GEMINI_API_KEY=test npm run build` | ✅ Success | Production bundle generated; noted Rollup chunk size warning for main bundle. |
+
 ## 2025-09-20
 
 | Step | Command | Result | Notes |

--- a/docs/deployment-log.md
+++ b/docs/deployment-log.md
@@ -2,6 +2,14 @@
 
 This log captures each run of the autonomous deployment plan in the local container environment.
 
+## 2025-09-20 (Run 4)
+
+| Step | Command | Result | Notes |
+|------|---------|--------|-------|
+| 1 | `npm ci` | ✅ Success | Clean reinstall completed in 4s; npm reported 5 moderate advisories to monitor. |
+| 2 | `npx vitest run --reporter=basic` | ✅ Success | All 22 Vitest suites passed; auth client fallback emitted expected ECONNREFUSED warning. |
+| 3 | `GEMINI_API_KEY=test VITE_GEMINI_API_KEY=test npm run build` | ✅ Success | Production bundle built in 3.8s; Rollup chunk-size warning persists and is tracked. |
+
 ## 2025-09-20 (Run 3)
 
 | Step | Command | Result | Notes |

--- a/docs/deployment-log.md
+++ b/docs/deployment-log.md
@@ -1,0 +1,13 @@
+# Deployment Run Log
+
+This log captures each run of the autonomous deployment plan in the local container environment.
+
+## 2025-09-20
+
+| Step | Command | Result | Notes |
+|------|---------|--------|-------|
+| 1 | `npm ci` | ✅ Success | Fresh install with npm cache; reported 5 moderate advisories. |
+| 2 | `npm run test -- --run` | ✅ Success | Vitest suites for auth client/API and utilities all passed. |
+| 3 | `GEMINI_API_KEY=test VITE_GEMINI_API_KEY=test npm run build` | ✅ Success | Generated production bundle; noted large chunk warning from Rollup. |
+
+All artefacts from the run are available in the local `node_modules/` cache and `dist/` build output. No manual intervention was required.

--- a/docs/deployment-log.md
+++ b/docs/deployment-log.md
@@ -2,6 +2,14 @@
 
 This log captures each run of the autonomous deployment plan in the local container environment.
 
+## 2025-09-20 (Run 5)
+
+| Step | Command | Result | Notes |
+|------|---------|--------|-------|
+| 1 | `npm ci` | ✅ Success | Fresh install finished in 4s; npm flagged 5 moderate advisories for monitoring. |
+| 2 | `npm run test -- --run` | ✅ Success | All 22 Vitest suites passed; expected mock fallback warning logged for offline auth client tests. |
+| 3 | `GEMINI_API_KEY=test VITE_GEMINI_API_KEY=test npm run build` | ✅ Success | Production build completed in 4.1s; Rollup chunk-size warning remains under observation. |
+
 ## 2025-09-20 (Run 4)
 
 | Step | Command | Result | Notes |

--- a/docs/deployment-plan.md
+++ b/docs/deployment-plan.md
@@ -1,0 +1,129 @@
+# Autonomous Deployment Plan
+
+## Objectives
+
+- Provide a hands-free deployment workflow that validates every change, keeps production in a releasable state, and publishes updates automatically after approval.
+- Guarantee that the Gemini-powered AI functionality keeps working across environments by managing credentials and configuration in the pipeline.
+- Offer clear operational guidance so engineers, QA, and product stakeholders can understand the release cadence, rollback levers, and monitoring touchpoints.
+
+## Environment Strategy
+
+| Environment | Purpose | Trigger | Hosting | Notes |
+|-------------|---------|---------|---------|-------|
+| Local | Feature development, exploratory testing | `npm run dev` | Developer machine | Requires a personal `VITE_GEMINI_API_KEY` in `.env.local`. |
+| Pull Request (CI) | Automated quality gate before merge | Pull requests to `main` | GitHub Actions `CI` workflow | Runs tests and build to catch regressions early. |
+| Production | Customer-facing release | Merge/push to `main` or manual trigger | GitHub Pages via `Deploy to GitHub Pages` workflow | Publishes the static Vite build (`dist/`). Requires `GEMINI_API_KEY` secret. |
+
+## Branching & Release Management
+
+1. **Feature branches**: developers branch from `main` and open pull requests when ready. Small, incremental changes are encouraged.
+2. **Pull request checks**: the `CI` workflow installs dependencies, runs Vitest, and builds the application. Merges are blocked until this workflow succeeds.
+3. **Production deployment**: merges to `main` automatically queue the deployment workflow. GitHub Pages retains the history of published revisions, enabling rollbacks by reverting commits.
+4. **Manual redeploy**: maintainers can use the `workflow_dispatch` trigger to redeploy the last successful build if infrastructure changes occur.
+
+## Pipeline Implementation
+
+### 1. Continuous Integration (`.github/workflows/ci.yml`)
+
+- **Checkout & toolchain**: uses `actions/checkout@v4` and `actions/setup-node@v4` with Node.js 20 and npm caching for repeatable builds.
+- **Dependency installation**: `npm ci` guarantees a clean install aligned with `package-lock.json`.
+- **Quality gates**:
+  - `npm run test -- --run` executes Vitest in run mode to surface failing suites.
+  - `npm run build` ensures the static bundle compiles before merge.
+- **Gemini credentials**: the build step reads `GEMINI_API_KEY`/`VITE_GEMINI_API_KEY` from repository secrets so tests that rely on the configuration can use fallbacks safely without exposing keys.
+
+### 2. Continuous Deployment (`.github/workflows/deploy.yml`)
+
+- **Trigger**: runs on pushes to `main` or on manual dispatch.
+- **Build job**: mirrors the CI installation/build process and uploads the Vite `dist/` directory as a GitHub Pages artifact.
+- **Deploy job**: publishes the artifact using `actions/deploy-pages@v4` into the `production` environment, exposing the deployed URL through environment metadata.
+- **Concurrency control**: prevents overlapping deploys by cancelling superseded runs (`group: pages`).
+
+### 3. Automation flow at a glance
+
+```
+developer push/PR --> CI workflow (install → test → build)
+                     │
+                     └── success on main? ──► Deploy workflow (build → upload → publish)
+                                                 │
+                                                 └── GitHub Pages production site
+```
+
+Every job emits workflow summary annotations. Configure branch protection to require the **CI** workflow before merging, ensuring only artefacts that pass automated checks can progress to production.
+
+### 4. Quality gates & artefacts
+
+- CI uploads Vitest results and the production build output (`dist/`) as ephemeral artefacts for debugging. Enable the "retention period" defaults (90 days) for traceability.
+- Deployment exposes the live URL and commit SHA in the run summary, giving stakeholders a direct link for smoke testing.
+- Timeout guards (15 minutes per job) fail fast if installations hang, notifying the team earlier.
+
+## Configuration & Secrets
+
+| Name | Type | Scope | Description |
+|------|------|-------|-------------|
+| `GEMINI_API_KEY` | Repository secret | Workflows | Gemini API key shared across build and runtime. Exposed to Vite as `VITE_GEMINI_API_KEY` during builds. |
+| `VITE_GEMINI_API_KEY` | Local env var | Developer machines | Developer-specific Gemini key for local testing. |
+
+**Setup checklist:**
+
+1. Store `GEMINI_API_KEY` in the repository secrets UI.
+2. Enable GitHub Pages for the repository with the "GitHub Actions" source.
+3. (Optional) Restrict the `production` environment with reviewers for controlled releases.
+
+## Observability & Quality Signals
+
+- **Workflow status**: monitor the `CI` and `Deploy to GitHub Pages` workflows in the Actions tab. Failures block releases.
+- **Pages deployment history**: GitHub Pages keeps a timeline of deployments for traceability.
+- **Release dashboards**: pin the Pages environment URL and latest workflow runs to the repository README or team dashboard for at-a-glance health.
+- **Synthetic checks**: configure an UptimeRobot/Checkly probe that hits the Pages URL after each deployment and alerts on non-200 responses.
+- **Runtime monitoring**: integrate browser analytics or error tracking (e.g., Google Analytics, Sentry) in future iterations to watch for regressions post-release.
+
+## Rollback & Incident Response
+
+1. **Immediate rollback**: revert or cherry-pick fixes onto `main`. The deployment workflow republishes automatically.
+2. **Hotfix policy**: create a hotfix branch from `main`, land the fix with an expedited PR, and allow CI to validate before deployment.
+3. **Secret rotation**: if the Gemini key is compromised, rotate it in the Google Cloud console and update the `GEMINI_API_KEY` secret. Redeploy using the manual trigger once updated.
+
+## Operational Runbooks
+
+### Pre-merge checklist (engineers)
+
+1. Branch from `main` and keep commits focused and reviewable.
+2. Run `npm run test` and `npm run build` locally before pushing to surface dependency issues earlier.
+3. Ensure relevant UI changes include screenshots or Storybook references for design sign-off.
+4. Verify any Gemini prompt or model updates against sandbox credentials before submitting the PR.
+
+### Post-deploy verification (QA / product)
+
+1. Inspect the GitHub Pages deployment summary to confirm the correct commit SHA and environment URL.
+2. Execute the smoke test checklist: application loads, Gemini-backed flows respond with expected latencies, and analytics beacons fire.
+3. Record the verification outcome in the deployment log (GitHub issue or Notion page) for auditability.
+
+### Incident playbook (on-call engineer)
+
+1. Capture context: failed workflow logs, Pages deployment status, and any user-facing impact.
+2. Decide on rollback vs. hotfix within 15 minutes of detection.
+3. Communicate status in the team channel and open an incident ticket containing root-cause hypotheses and mitigation steps.
+4. Schedule a retro once the incident is resolved to catalogue preventive actions.
+
+## Release Workflow & Responsibilities
+
+| Role | Primary duties | Handoffs |
+|------|----------------|----------|
+| Feature engineer | Develop features, author tests, maintain documentation, respond to PR feedback. | Signals QA once PR is ready and CI passes. |
+| Reviewer | Perform code review, confirm automated checks, ensure product/UX acceptance criteria are met. | Approves merge or requests changes. |
+| QA/Product | Conduct targeted exploratory testing on the deployed Pages environment. | Signs off in deployment log, alerts on regressions. |
+| On-call engineer | Monitors workflows, owns incident response, coordinates rollback/hotfix. | Updates stakeholders post-resolution. |
+
+## Maintenance Cadence
+
+- **Weekly**: prune stale preview branches, review GitHub Actions runtime usage, and refresh the deployment log with notable releases.
+- **Monthly**: rotate Gemini API keys, verify backup owners for the `production` environment, and update dependency snapshots via `npm audit fix --dry-run` for awareness.
+- **Quarterly**: revisit pipeline configuration (Node.js version, caching strategy) and expand automated checks (Lighthouse, accessibility) as the product evolves.
+
+## Future Enhancements
+
+- Add visual regression testing or Lighthouse checks to protect UX quality gates.
+- Integrate preview deployments for each pull request (e.g., Vercel/Netlify) if stakeholders need live QA sandboxes.
+- Automate notifications (Slack/Teams) on deployment completion and failures for better team awareness.
+- Expand monitoring with uptime checks and error alerting to close the feedback loop after release.

--- a/docs/deployment-plan.md
+++ b/docs/deployment-plan.md
@@ -12,14 +12,16 @@
 |-------------|---------|---------|---------|-------|
 | Local | Feature development, exploratory testing | `npm run dev` | Developer machine | Requires a personal `VITE_GEMINI_API_KEY` in `.env.local`. |
 | Pull Request (CI) | Automated quality gate before merge | Pull requests to `main` | GitHub Actions `CI` workflow | Runs tests and build to catch regressions early. |
-| Production | Customer-facing release | Merge/push to `main` or manual trigger | GitHub Pages via `Deploy to GitHub Pages` workflow | Publishes the static Vite build (`dist/`). Requires `GEMINI_API_KEY` secret. |
+| Preview | QA validation, stakeholder demos | Pull requests | Vercel preview deployments via `Deploy to Vercel` workflow | Uses the same build artefact as CI and publishes a shareable preview URL. |
+| Production | Customer-facing release | Merge/push to `main` or manual promotion | Vercel production environment via `Deploy to Vercel` workflow | Promotes the verified build; supports instant rollback from the Vercel dashboard. |
+| Static fallback | Optional static export | Manual trigger | GitHub Pages via `Deploy to GitHub Pages` workflow | Retained for backup hosting or disaster recovery drills. |
 
 ## Branching & Release Management
 
 1. **Feature branches**: developers branch from `main` and open pull requests when ready. Small, incremental changes are encouraged.
 2. **Pull request checks**: the `CI` workflow installs dependencies, runs Vitest, and builds the application. Merges are blocked until this workflow succeeds.
-3. **Production deployment**: merges to `main` automatically queue the deployment workflow. GitHub Pages retains the history of published revisions, enabling rollbacks by reverting commits.
-4. **Manual redeploy**: maintainers can use the `workflow_dispatch` trigger to redeploy the last successful build if infrastructure changes occur.
+3. **Production deployment**: merges to `main` automatically queue the **Deploy to Vercel** workflow, which promotes the tested artefact to the production environment. Vercel retains prior deployments, so rollbacks are a single click.
+4. **Manual redeploy**: maintainers can rerun the workflow from the Actions tab or use Vercel’s **Promote to Production** button on a validated preview build. The GitHub Pages workflow remains available for static redeploys if required.
 
 ## Pipeline Implementation
 
@@ -32,21 +34,30 @@
   - `npm run build` ensures the static bundle compiles before merge.
 - **Gemini credentials**: the build step reads `GEMINI_API_KEY`/`VITE_GEMINI_API_KEY` from repository secrets so tests that rely on the configuration can use fallbacks safely without exposing keys.
 
-### 2. Continuous Deployment (`.github/workflows/deploy.yml`)
+### 2. Continuous Deployment – Vercel (`.github/workflows/vercel-deploy.yml`)
 
-- **Trigger**: runs on pushes to `main` or on manual dispatch.
-- **Build job**: mirrors the CI installation/build process and uploads the Vite `dist/` directory as a GitHub Pages artifact.
-- **Deploy job**: publishes the artifact using `actions/deploy-pages@v4` into the `production` environment, exposing the deployed URL through environment metadata.
-- **Concurrency control**: prevents overlapping deploys by cancelling superseded runs (`group: pages`).
+- **Trigger**: runs on pull requests and pushes to `main`.
+- **Quality gates**: repeats installation, tests, and the production build so the Vercel deploy only executes when artefacts are green.
+- **Preview deploys**: pull requests publish prebuilt artefacts to the Vercel preview environment and expose the URL via workflow summary/environment metadata.
+- **Production deploys**: pushes to `main` reuse the same artefact and promote it to the production environment with zero downtime. A fallback step mirrors `GEMINI_API_KEY` into `VITE_GEMINI_API_KEY` when only the server-side secret is configured.
+- **Concurrency control**: cancels superseded runs per branch (`group: vercel-${{ github.ref }}`) so only the latest commit deploys.
+- **Environment sync**: `npx vercel pull` keeps the `.vercel` directory in sync, ensuring local CLI usage matches CI.
 
-### 3. Automation flow at a glance
+### 3. Static export fallback (`.github/workflows/deploy.yml`)
+
+- **Trigger**: manual or pushes to `main` when GitHub Pages hosting is required.
+- **Purpose**: retain the previous Pages-based deployment mechanism for redundancy or migration windows.
+- **Operation**: builds the Vite project and publishes to GitHub Pages via `actions/deploy-pages@v4`.
+
+### 4. Automation flow at a glance
 
 ```
 developer push/PR --> CI workflow (install → test → build)
                      │
-                     └── success on main? ──► Deploy workflow (build → upload → publish)
-                                                 │
-                                                 └── GitHub Pages production site
+                     └── success ──► Deploy to Vercel workflow (install → test → build → deploy)
+                                           │
+                                           ├── pull request ➜ Vercel preview URL
+                                           └── main branch  ➜ Vercel production site
 ```
 
 Every job emits workflow summary annotations. Configure branch protection to require the **CI** workflow before merging, ensuring only artefacts that pass automated checks can progress to production.
@@ -61,21 +72,25 @@ Every job emits workflow summary annotations. Configure branch protection to req
 
 | Name | Type | Scope | Description |
 |------|------|-------|-------------|
-| `GEMINI_API_KEY` | Repository secret | Workflows | Gemini API key shared across build and runtime. Exposed to Vite as `VITE_GEMINI_API_KEY` during builds. |
-| `VITE_GEMINI_API_KEY` | Local env var | Developer machines | Developer-specific Gemini key for local testing. |
+| `GEMINI_API_KEY` | Repository secret | Workflows | Gemini API key shared across build and runtime. Used as the fallback client key when `VITE_GEMINI_API_KEY` is absent. |
+| `VITE_GEMINI_API_KEY` | Repository secret / local env var | Workflows & developer machines | Client-exposed Gemini key. Mirror the server key in secrets and set a personal value in `.env.local` for local runs. |
+| `VERCEL_TOKEN` | Repository secret | Workflows | Token used by the GitHub Action to authenticate with Vercel. Generate from Vercel account settings. |
+| `VERCEL_ORG_ID` | Repository secret | Workflows | Organization identifier from the Vercel project settings. |
+| `VERCEL_PROJECT_ID` | Repository secret | Workflows | Project identifier from the Vercel project settings. |
 
 **Setup checklist:**
 
-1. Store `GEMINI_API_KEY` in the repository secrets UI.
-2. Enable GitHub Pages for the repository with the "GitHub Actions" source.
-3. (Optional) Restrict the `production` environment with reviewers for controlled releases.
+1. Store `GEMINI_API_KEY`, `VITE_GEMINI_API_KEY`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` in the repository secrets UI.
+2. Connect the repository to a Vercel project and configure the environment variables described in [docs/vercel-deployment.md](vercel-deployment.md).
+3. (Optional) Enable GitHub Pages with the "GitHub Actions" source to keep the static fallback workflow operational.
+4. (Optional) Restrict the `production` environment with reviewers for controlled releases.
 
 ## Observability & Quality Signals
 
-- **Workflow status**: monitor the `CI` and `Deploy to GitHub Pages` workflows in the Actions tab. Failures block releases.
-- **Pages deployment history**: GitHub Pages keeps a timeline of deployments for traceability.
-- **Release dashboards**: pin the Pages environment URL and latest workflow runs to the repository README or team dashboard for at-a-glance health.
-- **Synthetic checks**: configure an UptimeRobot/Checkly probe that hits the Pages URL after each deployment and alerts on non-200 responses.
+- **Workflow status**: monitor the `CI` and `Deploy to Vercel` workflows in the Actions tab. Failures block releases.
+- **Deployment history**: Vercel exposes preview/production timelines and build logs for traceability. If you keep the Pages fallback, monitor its workflow as well.
+- **Release dashboards**: pin the latest Vercel preview/production URLs (and fallback host, if used) to the team dashboard for at-a-glance health.
+- **Synthetic checks**: configure an UptimeRobot/Checkly probe that hits the Vercel production URL after each deployment and alerts on non-200 responses. Mirror the check for the Pages fallback when active.
 - **Runtime monitoring**: integrate browser analytics or error tracking (e.g., Google Analytics, Sentry) in future iterations to watch for regressions post-release.
 
 ## Rollback & Incident Response
@@ -95,13 +110,13 @@ Every job emits workflow summary annotations. Configure branch protection to req
 
 ### Post-deploy verification (QA / product)
 
-1. Inspect the GitHub Pages deployment summary to confirm the correct commit SHA and environment URL.
+1. Inspect the Vercel deployment summary (preview or production) to confirm the correct commit SHA and environment URL.
 2. Execute the smoke test checklist: application loads, Gemini-backed flows respond with expected latencies, and analytics beacons fire.
-3. Record the verification outcome in the deployment log (GitHub issue or Notion page) for auditability.
+3. Record the verification outcome in the deployment log (GitHub issue or Notion page) for auditability. Include fallback host status if used.
 
 ### Incident playbook (on-call engineer)
 
-1. Capture context: failed workflow logs, Pages deployment status, and any user-facing impact.
+1. Capture context: failed workflow logs, Vercel deployment status, and any user-facing impact. Include Pages fallback signals if the backup host is active.
 2. Decide on rollback vs. hotfix within 15 minutes of detection.
 3. Communicate status in the team channel and open an incident ticket containing root-cause hypotheses and mitigation steps.
 4. Schedule a retro once the incident is resolved to catalogue preventive actions.
@@ -112,7 +127,7 @@ Every job emits workflow summary annotations. Configure branch protection to req
 |------|----------------|----------|
 | Feature engineer | Develop features, author tests, maintain documentation, respond to PR feedback. | Signals QA once PR is ready and CI passes. |
 | Reviewer | Perform code review, confirm automated checks, ensure product/UX acceptance criteria are met. | Approves merge or requests changes. |
-| QA/Product | Conduct targeted exploratory testing on the deployed Pages environment. | Signs off in deployment log, alerts on regressions. |
+| QA/Product | Conduct targeted exploratory testing on the deployed Vercel preview/production environment (and fallback host when used). | Signs off in deployment log, alerts on regressions. |
 | On-call engineer | Monitors workflows, owns incident response, coordinates rollback/hotfix. | Updates stakeholders post-resolution. |
 
 ## Maintenance Cadence
@@ -123,7 +138,6 @@ Every job emits workflow summary annotations. Configure branch protection to req
 
 ## Future Enhancements
 
-- Add visual regression testing or Lighthouse checks to protect UX quality gates.
-- Integrate preview deployments for each pull request (e.g., Vercel/Netlify) if stakeholders need live QA sandboxes.
+- Add visual regression or Lighthouse checks directly in the Vercel pipeline to protect UX quality gates.
 - Automate notifications (Slack/Teams) on deployment completion and failures for better team awareness.
 - Expand monitoring with uptime checks and error alerting to close the feedback loop after release.

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -1,0 +1,74 @@
+# Vercel Deployment Guide
+
+This document describes how to connect the project to Vercel for preview and production hosting.
+
+## Prerequisites
+
+- Vercel account with access to create projects and manage environment variables.
+- Vercel CLI (`npm i -g vercel`) for local validation (optional but recommended).
+- GitHub repository admin access to configure secrets for the automation workflow.
+
+## 1. Create the Vercel project
+
+1. Navigate to the Vercel dashboard and click **Add New… → Project**.
+2. Import this GitHub repository and keep the default **Vite** framework detection.
+3. When prompted for the build command and output directory, accept the defaults: `npm run build` and `dist`.
+4. Finish the import; the first build will run once the required environment variables are provided (next section).
+
+## 2. Configure environment variables
+
+Set the following variables in the Vercel dashboard (`Settings → Environment Variables`):
+
+| Name | Environment | Description |
+| ---- | ----------- | ----------- |
+| `GEMINI_API_KEY` | Preview & Production | Server-side Gemini key used by API routes and for parity with local builds. |
+| `VITE_GEMINI_API_KEY` | Preview & Production | Client-exposed Gemini key injected at build time. Use the same value as `GEMINI_API_KEY` if you only manage one credential. |
+| `VITE_API_BASE_URL` | Optional per environment | Set if you connect the UI to an external authentication service. Leave unset to use the encrypted in-browser mock API. |
+
+The `vercel.json` file also declares named secrets (`@gemini_api_key`, `@preview_api_base_url`, `@production_api_base_url`). You can manage them with the CLI:
+
+```bash
+# Add/update shared Gemini secret
+vercel secrets add gemini_api_key YOUR_KEY_VALUE
+
+# Optional: different API base URLs for preview and production
+vercel secrets add preview_api_base_url https://staging.example.com
+vercel secrets add production_api_base_url https://auth.example.com
+```
+
+## 3. Connect GitHub Actions deployment
+
+The workflow at [`.github/workflows/vercel-deploy.yml`](../.github/workflows/vercel-deploy.yml) handles previews (pull requests) and production deployments (pushes to `main`). Configure these repository secrets in GitHub (`Settings → Secrets and variables → Actions`):
+
+| Secret | Purpose |
+| ------ | ------- |
+| `VERCEL_TOKEN` | Personal token from the Vercel dashboard (`Account Settings → Tokens`). |
+| `VERCEL_ORG_ID` | Organization ID, available under the project’s **Settings → General** page. |
+| `VERCEL_PROJECT_ID` | Project ID from the same settings page. |
+| `GEMINI_API_KEY` | Shared Gemini credential; used during CI builds and as a fallback if `VITE_GEMINI_API_KEY` isn’t provided. |
+| `VITE_GEMINI_API_KEY` | (Optional) Client-side Gemini key if you need a distinct credential. |
+
+Once the secrets are in place, every pull request receives a preview URL and merges to `main` publish to the production environment. The workflow cancels superseded runs so only the latest commit deploys.
+
+## 4. Local preview with Vercel CLI (optional)
+
+Developers can validate the Vercel build locally:
+
+```bash
+# Pull environment variables defined in vercel.json / dashboard
+vercel pull --yes --environment=preview
+
+# Build using the same command as CI
+npm run build
+
+# Deploy a disposable preview (requires VERCEL_TOKEN)
+vercel deploy --prebuilt
+```
+
+## 5. Monitoring & rollback
+
+- Vercel retains build logs and deployment history in the project dashboard.
+- Use the **Promote to Production** button on a successful preview deployment for controlled releases.
+- Roll back by selecting a previous deployment and clicking **Rollback**; the GitHub workflow will pick up the new production URL automatically.
+
+For more operational details (testing expectations, incident response, on-call flow), refer to [docs/deployment-plan.md](deployment-plan.md).

--- a/hooks/useReminderService.ts
+++ b/hooks/useReminderService.ts
@@ -3,12 +3,14 @@ import React, { useEffect, useCallback } from 'react';
 import { User, Task } from '../types';
 // FIX: Corrected API import
 import { api } from '../services/mockApi';
+import { getStorage } from '../utils/storage';
 
 const REMINDERS_FIRED_KEY = 'asagents_reminders_fired';
+const storage = getStorage();
 
 const getFiredReminders = (): (string|number)[] => {
     try {
-        const raw = localStorage.getItem(REMINDERS_FIRED_KEY);
+        const raw = storage.getItem(REMINDERS_FIRED_KEY);
         return raw ? JSON.parse(raw) : [];
     } catch (e) {
         return [];
@@ -19,7 +21,7 @@ const addFiredReminder = (todoId: string | number) => {
     const fired = getFiredReminders();
     if (!fired.includes(todoId)) {
         fired.push(todoId);
-        localStorage.setItem(REMINDERS_FIRED_KEY, JSON.stringify(fired));
+        storage.setItem(REMINDERS_FIRED_KEY, JSON.stringify(fired));
     }
 };
 

--- a/services/__tests__/authApi.test.ts
+++ b/services/__tests__/authApi.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { webcrypto } from 'node:crypto';
+import { authApi, resetMockApi } from '../mockApi';
+import { resetInMemoryStorage } from '../../utils/storage';
+import { Role } from '../../types';
+
+if (!globalThis.crypto) {
+    Object.defineProperty(globalThis, 'crypto', {
+        value: webcrypto,
+        configurable: true,
+    });
+}
+
+describe('authApi', () => {
+    beforeEach(() => {
+        resetInMemoryStorage();
+        resetMockApi();
+    });
+
+    it('registers a new workspace owner and allows login', async () => {
+        const payload = {
+            firstName: 'Taylor',
+            lastName: 'Reed',
+            email: 'taylor@buildright.com',
+            password: 'Password!1',
+            companySelection: 'create' as const,
+            companyName: 'Build Right Ltd',
+            companyType: 'GENERAL_CONTRACTOR' as const,
+            termsAccepted: true,
+        };
+
+        const response = await authApi.register(payload);
+
+        expect(response.user.email).toBe(payload.email);
+        expect(response.user.role).toBe(Role.OWNER);
+        expect(response.company.name).toBe(payload.companyName);
+        expect(response.token).toBeTruthy();
+
+        const loginResponse = await authApi.login({ email: payload.email, password: payload.password });
+        expect(loginResponse.user.id).toBe(response.user.id);
+    });
+
+    it('prevents duplicate email registration', async () => {
+        const payload = {
+            firstName: 'Jordan',
+            lastName: 'Quinn',
+            email: 'duplicate@workspace.com',
+            password: 'Password!1',
+            companySelection: 'create' as const,
+            companyName: 'Duplicate Co',
+            companyType: 'CONSULTANT' as const,
+            termsAccepted: true,
+        };
+
+        await authApi.register(payload);
+        await expect(authApi.register(payload)).rejects.toThrow(/already exists/i);
+    });
+
+    it('registers a user against an invite token', async () => {
+        const invite = await authApi.lookupInviteToken('JOIN-CONSTRUCTCO');
+        expect(invite.companyId).toBe('1');
+
+        const joinResponse = await authApi.register({
+            firstName: 'Jamie',
+            lastName: 'Lopez',
+            email: 'jamie@invite.com',
+            password: 'Password!1',
+            companySelection: 'join',
+            inviteToken: 'JOIN-CONSTRUCTCO',
+            role: invite.allowedRoles[0],
+            termsAccepted: true,
+        });
+
+        expect(joinResponse.user.companyId).toBe(invite.companyId);
+        expect(invite.allowedRoles).toContain(joinResponse.user.role);
+    });
+
+    it('rejects invalid login attempts', async () => {
+        await expect(authApi.login({ email: 'sam@constructco.com', password: 'wrongpass' })).rejects.toThrow(/invalid email or password/i);
+    });
+});

--- a/services/__tests__/authClient.test.ts
+++ b/services/__tests__/authClient.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { webcrypto } from 'node:crypto';
+import { authClient, configureAuthClient, getAuthConnectionInfo, resetAuthClient } from '../authClient';
+import { resetMockApi } from '../mockApi';
+import { resetInMemoryStorage } from '../../utils/storage';
+
+if (!globalThis.crypto) {
+    Object.defineProperty(globalThis, 'crypto', {
+        value: webcrypto,
+        configurable: true,
+    });
+}
+
+describe('authClient', () => {
+    beforeEach(() => {
+        resetInMemoryStorage();
+        resetMockApi();
+        resetAuthClient();
+    });
+
+    afterEach(() => {
+        resetAuthClient();
+        vi.restoreAllMocks();
+    });
+
+    it('uses the local mock implementation when no backend is configured', async () => {
+        const connection = getAuthConnectionInfo();
+        expect(connection.mode).toBe('mock');
+
+        const payload = {
+            firstName: 'Casey',
+            lastName: 'Jordan',
+            email: 'casey@demo.dev',
+            password: 'Password!1',
+            companySelection: 'create' as const,
+            companyName: 'Demo Builders',
+            companyType: 'GENERAL_CONTRACTOR' as const,
+            termsAccepted: true,
+        };
+
+        const registration = await authClient.register(payload);
+        expect(registration.user.email).toBe(payload.email);
+
+        const login = await authClient.login({ email: payload.email, password: payload.password });
+        if ('mfaRequired' in login && login.mfaRequired) {
+            expect(login.userId).toBeTruthy();
+        } else {
+            expect(login.token).toBeTruthy();
+        }
+    });
+
+    it('falls back to the mock implementation when the backend is unreachable and fallback is enabled', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('connect ECONNREFUSED'));
+        configureAuthClient({ baseUrl: 'https://api.example.test', allowMockFallback: true });
+
+        const payload = {
+            firstName: 'Morgan',
+            lastName: 'Reid',
+            email: 'morgan@fallback.dev',
+            password: 'Password!1',
+            companySelection: 'create' as const,
+            companyName: 'Fallback Works',
+            companyType: 'CONSULTANT' as const,
+            termsAccepted: true,
+        };
+
+        const registration = await authClient.register(payload);
+        expect(registration.user.email).toBe(payload.email);
+        expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    it('surfaces an error when the backend is unreachable and fallback is disabled', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('connect ECONNREFUSED'));
+        configureAuthClient({ baseUrl: 'https://api.example.test', allowMockFallback: false });
+
+        await expect(authClient.login({ email: 'someone@example.com', password: 'Password!1' })).rejects.toThrow(
+            /authentication service is currently unavailable/i
+        );
+        expect(fetchSpy).toHaveBeenCalled();
+    });
+});
+

--- a/services/authClient.ts
+++ b/services/authClient.ts
@@ -1,0 +1,235 @@
+import { authApi } from './mockApi';
+import type { LoginCredentials, RegistrationPayload, User, Company, Role, CompanyType } from '../types';
+
+export type AuthenticatedSession = {
+    success: true;
+    token: string;
+    refreshToken: string;
+    user: User;
+    company: Company;
+};
+
+export type LoginResult =
+    | (AuthenticatedSession & { mfaRequired?: false })
+    | { success: true; mfaRequired: true; userId: string };
+
+export type InvitePreview = {
+    companyId: string;
+    companyName: string;
+    companyType?: CompanyType;
+    allowedRoles: Role[];
+    suggestedRole?: Role;
+};
+
+export type EmailAvailability = { available: boolean };
+
+class BackendUnavailableError extends Error {
+    constructor(message: string, public cause?: unknown) {
+        super(message);
+        this.name = 'BackendUnavailableError';
+    }
+}
+
+const sanitizeBaseUrl = (value?: string | null): string | null => {
+    if (!value) {
+        return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return null;
+    }
+    return trimmed.replace(/\/+$/, '');
+};
+
+const detectBaseUrl = (): string | null => {
+    if (typeof window !== 'undefined' && typeof (window as any).__ASAGENTS_API_BASE_URL__ === 'string') {
+        return sanitizeBaseUrl((window as any).__ASAGENTS_API_BASE_URL__);
+    }
+    if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE_URL) {
+        return sanitizeBaseUrl((import.meta as any).env.VITE_API_BASE_URL);
+    }
+    if (typeof process !== 'undefined' && typeof process.env?.VITE_API_BASE_URL === 'string') {
+        return sanitizeBaseUrl(process.env.VITE_API_BASE_URL);
+    }
+    return null;
+};
+
+const initialBaseUrl = detectBaseUrl();
+let runtimeBaseUrl = initialBaseUrl;
+let allowMockFallback = !runtimeBaseUrl;
+
+const buildHeaders = (headers: HeadersInit | undefined, body: BodyInit | null | undefined) => {
+    const composed = new Headers(headers ?? {});
+    if (!composed.has('Accept')) {
+        composed.set('Accept', 'application/json');
+    }
+    if (body != null && body !== '' && !composed.has('Content-Type')) {
+        composed.set('Content-Type', 'application/json');
+    }
+    return composed;
+};
+
+const ensureLeadingSlash = (path: string) => (path.startsWith('/') ? path : `/${path}`);
+
+const request = async <T>(path: string, init: RequestInit): Promise<T> => {
+    if (!runtimeBaseUrl) {
+        throw new BackendUnavailableError('No authentication backend configured.');
+    }
+
+    const url = `${runtimeBaseUrl}${ensureLeadingSlash(path)}`;
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            ...init,
+            headers: buildHeaders(init.headers, init.body ?? undefined),
+        });
+    } catch (error) {
+        throw new BackendUnavailableError('Unable to reach authentication service.', error);
+    }
+
+    let data: any = null;
+    const contentType = response.headers.get('content-type');
+    if (contentType && contentType.includes('application/json')) {
+        data = await response.json();
+    } else {
+        const text = await response.text();
+        data = text ? { message: text } : {};
+    }
+
+    if (!response.ok) {
+        const message = data?.message || data?.error || `Request failed with status ${response.status}`;
+        const error: any = new Error(message);
+        error.status = response.status;
+        error.details = data;
+        throw error;
+    }
+
+    return data as T;
+};
+
+const withAuthFallback = async <T>(path: string, init: RequestInit, fallback: () => Promise<T>): Promise<T> => {
+    if (!runtimeBaseUrl) {
+        return fallback();
+    }
+    try {
+        return await request<T>(path, init);
+    } catch (error) {
+        if (error instanceof BackendUnavailableError) {
+            if (allowMockFallback) {
+                console.warn('[authClient] Falling back to local mock authentication.', error);
+                return fallback();
+            }
+            const friendly = new Error('Authentication service is currently unavailable. Please try again later.');
+            (friendly as any).cause = error;
+            throw friendly;
+        }
+        throw error;
+    }
+};
+
+export const configureAuthClient = (options: { baseUrl?: string | null; allowMockFallback?: boolean } = {}) => {
+    if (Object.prototype.hasOwnProperty.call(options, 'baseUrl')) {
+        runtimeBaseUrl = sanitizeBaseUrl(options.baseUrl ?? null);
+        if (Object.prototype.hasOwnProperty.call(options, 'allowMockFallback')) {
+            allowMockFallback = !!options.allowMockFallback;
+        } else {
+            allowMockFallback = !runtimeBaseUrl;
+        }
+    } else if (Object.prototype.hasOwnProperty.call(options, 'allowMockFallback')) {
+        allowMockFallback = !!options.allowMockFallback;
+    }
+};
+
+export const resetAuthClient = () => {
+    runtimeBaseUrl = initialBaseUrl;
+    allowMockFallback = !runtimeBaseUrl;
+};
+
+const formatBaseHost = (baseUrl: string | null) => {
+    if (!baseUrl) {
+        return null;
+    }
+    try {
+        return new URL(baseUrl).host;
+    } catch {
+        return baseUrl.replace(/^https?:\/\//, '');
+    }
+};
+
+export const getAuthConnectionInfo = () => ({
+    mode: runtimeBaseUrl ? ('backend' as const) : ('mock' as const),
+    baseUrl: runtimeBaseUrl,
+    baseHost: formatBaseHost(runtimeBaseUrl),
+    allowMockFallback,
+});
+
+export const authClient = {
+    login: (credentials: LoginCredentials): Promise<LoginResult> =>
+        withAuthFallback<LoginResult>(
+            '/auth/login',
+            { method: 'POST', body: JSON.stringify(credentials) },
+            () => authApi.login(credentials)
+        ),
+
+    register: (payload: RegistrationPayload): Promise<AuthenticatedSession> =>
+        withAuthFallback<AuthenticatedSession>(
+            '/auth/register',
+            { method: 'POST', body: JSON.stringify(payload) },
+            () => authApi.register(payload)
+        ),
+
+    verifyMfa: (userId: string, code: string): Promise<AuthenticatedSession> =>
+        withAuthFallback<AuthenticatedSession>(
+            '/auth/mfa/verify',
+            { method: 'POST', body: JSON.stringify({ userId, code }) },
+            () => authApi.verifyMfa(userId, code)
+        ),
+
+    refreshToken: (refreshToken: string): Promise<{ token: string }> =>
+        withAuthFallback<{ token: string }>(
+            '/auth/token/refresh',
+            { method: 'POST', body: JSON.stringify({ refreshToken }) },
+            () => authApi.refreshToken(refreshToken)
+        ),
+
+    me: (token: string): Promise<{ user: User; company: Company }> =>
+        withAuthFallback<{ user: User; company: Company }>(
+            '/auth/me',
+            {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            },
+            () => authApi.me(token)
+        ),
+
+    checkEmailAvailability: (email: string): Promise<EmailAvailability> =>
+        withAuthFallback<EmailAvailability>(
+            `/auth/email-availability?email=${encodeURIComponent(email)}`,
+            { method: 'GET' },
+            () => authApi.checkEmailAvailability(email)
+        ),
+
+    lookupInviteToken: (token: string): Promise<InvitePreview> =>
+        withAuthFallback<InvitePreview>(
+            `/auth/invites/${encodeURIComponent(token)}`,
+            { method: 'GET' },
+            () => authApi.lookupInviteToken(token)
+        ),
+
+    requestPasswordReset: (email: string): Promise<{ success: boolean }> =>
+        withAuthFallback<{ success: boolean }>(
+            '/auth/password/request-reset',
+            { method: 'POST', body: JSON.stringify({ email }) },
+            () => authApi.requestPasswordReset(email)
+        ),
+
+    resetPassword: (token: string, newPassword: string): Promise<{ success: boolean }> =>
+        withAuthFallback<{ success: boolean }>(
+            '/auth/password/reset',
+            { method: 'POST', body: JSON.stringify({ token, newPassword }) },
+            () => authApi.resetPassword(token, newPassword)
+        ),
+};
+

--- a/services/mockApi.ts
+++ b/services/mockApi.ts
@@ -1,8 +1,10 @@
-// A mock API using localStorage to simulate a backend.
+// A mock API that persists data using a browser-like storage adapter.
 // Supports offline queuing for write operations.
 
 import { initialData } from './mockData';
-import { User, Company, Project, Task, TimeEntry, SafetyIncident, Equipment, Client, Invoice, Expense, Notification, LoginCredentials, RegisterCredentials, TaskStatus, TaskPriority, TimeEntryStatus, IncidentSeverity, SiteUpdate, ProjectMessage, Weather, InvoiceStatus, Quote, FinancialKPIs, MonthlyFinancials, CostBreakdown, Role, TimesheetStatus, IncidentStatus, AuditLog, ResourceAssignment, Conversation, Message, CompanySettings, ProjectAssignment, ProjectTemplate, ProjectInsight, WhiteboardNote, BidPackage, RiskAnalysis, Grant, Timesheet, Todo, InvoiceLineItem, Document, UsageMetric, CompanyType, ExpenseStatus, TodoStatus, TodoPriority } from '../types';
+import { User, Company, Project, Task, TimeEntry, SafetyIncident, Equipment, Client, Invoice, Expense, Notification, LoginCredentials, RegistrationPayload, TaskStatus, TaskPriority, TimeEntryStatus, IncidentSeverity, SiteUpdate, ProjectMessage, Weather, InvoiceStatus, Quote, FinancialKPIs, MonthlyFinancials, CostBreakdown, Role, TimesheetStatus, IncidentStatus, AuditLog, ResourceAssignment, Conversation, Message, CompanySettings, ProjectAssignment, ProjectTemplate, ProjectInsight, WhiteboardNote, BidPackage, RiskAnalysis, Grant, Timesheet, Todo, InvoiceLineItem, Document, UsageMetric, CompanyType, ExpenseStatus, TodoStatus, TodoPriority, RolePermissions, Permission } from '../types';
+import { createPasswordRecord, sanitizeUser, upgradeLegacyPassword, verifyPassword } from '../utils/password';
+import { getStorage } from '../utils/storage';
 
 const delay = (ms = 50) => new Promise(res => setTimeout(res, ms));
 
@@ -19,8 +21,87 @@ const MOCK_ACCESS_TOKEN_LIFESPAN = 15 * 60 * 1000; // 15 minutes
 const MOCK_REFRESH_TOKEN_LIFESPAN = 7 * 24 * 60 * 60 * 1000; // 7 days
 const MOCK_RESET_TOKEN_LIFESPAN = 60 * 60 * 1000; // 1 hour
 
+const normalizeEmail = (email: string) => email.trim().toLowerCase();
+const normalizeInviteToken = (token: string) => token.trim().toUpperCase();
+
 // In-memory store for password reset tokens for this mock implementation
 const passwordResetTokens = new Map<string, { userId: string, expires: number }>();
+const storage = getStorage();
+
+type InviteTokenConfig = {
+    companyId: string;
+    allowedRoles: Role[];
+    suggestedRole?: Role;
+};
+
+const BASE_INVITE_TOKENS: Array<[string, InviteTokenConfig]> = [
+    ['JOIN-CONSTRUCTCO', {
+        companyId: '1',
+        allowedRoles: [Role.ADMIN, Role.PROJECT_MANAGER, Role.FOREMAN, Role.OPERATIVE],
+        suggestedRole: Role.PROJECT_MANAGER,
+    }],
+    ['JOIN-RENOVATE', {
+        companyId: '2',
+        allowedRoles: [Role.ADMIN, Role.PROJECT_MANAGER, Role.FOREMAN, Role.OPERATIVE],
+        suggestedRole: Role.FOREMAN,
+    }],
+    ['JOIN-CLIENT', {
+        companyId: '3',
+        allowedRoles: [Role.CLIENT],
+        suggestedRole: Role.CLIENT,
+    }],
+];
+
+const inviteTokenDirectory = new Map<string, InviteTokenConfig>();
+
+const resetInviteTokens = () => {
+    inviteTokenDirectory.clear();
+    BASE_INVITE_TOKENS.forEach(([token, config]) => {
+        inviteTokenDirectory.set(token, { ...config });
+    });
+};
+
+resetInviteTokens();
+
+const defaultCompanySettings = (): CompanySettings => ({
+    theme: 'light',
+    accessibility: { highContrast: false },
+    timeZone: 'Europe/London',
+    dateFormat: 'DD/MM/YYYY',
+    currency: 'GBP',
+    workingHours: {
+        start: '08:00',
+        end: '17:00',
+        workDays: [1, 2, 3, 4, 5],
+    },
+    features: {
+        projectManagement: true,
+        timeTracking: true,
+        financials: true,
+        documents: true,
+        safety: true,
+        equipment: true,
+        reporting: true,
+    },
+});
+
+const defaultUserPreferences = (): User['preferences'] => ({
+    theme: 'system',
+    language: 'en',
+    notifications: {
+        email: true,
+        push: false,
+        sms: false,
+        taskReminders: true,
+        projectUpdates: true,
+        systemAlerts: true,
+    },
+    dashboard: {
+        defaultView: 'dashboard',
+        pinnedWidgets: [],
+        hiddenWidgets: [],
+    },
+});
 
 const createToken = (payload: object, expiresIn: number): string => {
     const header = { alg: 'HS256', typ: 'JWT' };
@@ -50,18 +131,28 @@ const decodeToken = (token: string): any => {
     }
 };
 
-const hydrateData = <T extends { [key: string]: any }>(key: string, defaultData: T[]): T[] => {
+const STORAGE_PREFIX = 'asagents_';
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const readJson = <T>(key: string, fallback: T): T => {
     try {
-        const stored = localStorage.getItem(`asagents_${key}`);
-        if (stored) return JSON.parse(stored);
-    } catch (e) {
-        console.error(`Failed to hydrate ${key} from localStorage`, e);
+        const stored = storage.getItem(key);
+        if (!stored) {
+            return fallback;
+        }
+        return JSON.parse(stored) as T;
+    } catch (error) {
+        console.error(`Failed to read ${key} from storage`, error);
+        return fallback;
     }
-    localStorage.setItem(`asagents_${key}`, JSON.stringify(defaultData));
-    return defaultData;
 };
 
-let db: {
+const writeJson = (key: string, value: unknown) => {
+    storage.setItem(key, JSON.stringify(value));
+};
+
+type DbCollections = {
     companies: Partial<Company>[];
     users: Partial<User>[];
     projects: Partial<Project>[];
@@ -85,37 +176,120 @@ let db: {
     whiteboardNotes: Partial<WhiteboardNote>[];
     documents: Partial<Document>[];
     projectInsights: Partial<ProjectInsight>[];
-} = {
-    companies: hydrateData('companies', initialData.companies),
-    users: hydrateData('users', initialData.users),
-    projects: hydrateData('projects', initialData.projects),
-    todos: hydrateData('todos', initialData.todos),
-    timeEntries: hydrateData('timeEntries', initialData.timeEntries),
-    safetyIncidents: hydrateData('safetyIncidents', initialData.safetyIncidents),
-    equipment: hydrateData('equipment', initialData.equipment),
-    clients: hydrateData('clients', initialData.clients),
-    invoices: hydrateData('invoices', initialData.invoices),
-    expenses: hydrateData('expenses', initialData.expenses),
-    siteUpdates: hydrateData('siteUpdates', initialData.siteUpdates),
-    projectMessages: hydrateData('projectMessages', initialData.projectMessages),
-    notifications: hydrateData('notifications', (initialData as any).notifications || []),
-    quotes: hydrateData('quotes', (initialData as any).quotes || []),
-    auditLogs: hydrateData('auditLogs', []),
-    resourceAssignments: hydrateData('resourceAssignments', []),
-    conversations: hydrateData('conversations', []),
-    messages: hydrateData('messages', []),
-    projectAssignments: hydrateData('projectAssignments', []),
-    projectTemplates: hydrateData('projectTemplates', []),
-    whiteboardNotes: hydrateData('whiteboardNotes', []),
-    documents: hydrateData('documents', []),
-    projectInsights: hydrateData('projectInsights', (initialData as any).projectInsights || []),
 };
 
+const DEFAULT_COLLECTIONS: Record<keyof DbCollections, any[]> = {
+    companies: clone(initialData.companies),
+    users: clone(initialData.users),
+    projects: clone(initialData.projects),
+    todos: clone(initialData.todos),
+    timeEntries: clone(initialData.timeEntries),
+    safetyIncidents: clone(initialData.safetyIncidents),
+    equipment: clone(initialData.equipment),
+    clients: clone(initialData.clients),
+    invoices: clone(initialData.invoices),
+    expenses: clone((initialData as any).expenses || []),
+    siteUpdates: clone(initialData.siteUpdates),
+    projectMessages: clone(initialData.projectMessages),
+    notifications: clone((initialData as any).notifications || []),
+    quotes: clone((initialData as any).quotes || []),
+    auditLogs: [],
+    resourceAssignments: [],
+    conversations: [],
+    messages: [],
+    projectAssignments: [],
+    projectTemplates: [],
+    whiteboardNotes: [],
+    documents: [],
+    projectInsights: clone((initialData as any).projectInsights || []),
+};
+
+const readCollection = <K extends keyof DbCollections>(key: K): DbCollections[K] => {
+    const storageKey = `${STORAGE_PREFIX}${String(key)}`;
+    try {
+        const stored = storage.getItem(storageKey);
+        if (stored) {
+            return JSON.parse(stored);
+        }
+    } catch (error) {
+        console.error(`Failed to hydrate ${String(key)} from storage`, error);
+    }
+    const fallback = clone(DEFAULT_COLLECTIONS[key]);
+    storage.setItem(storageKey, JSON.stringify(fallback));
+    return fallback;
+};
+
+const createDb = (): DbCollections => ({
+    companies: readCollection('companies'),
+    users: readCollection('users'),
+    projects: readCollection('projects'),
+    todos: readCollection('todos'),
+    timeEntries: readCollection('timeEntries'),
+    safetyIncidents: readCollection('safetyIncidents'),
+    equipment: readCollection('equipment'),
+    clients: readCollection('clients'),
+    invoices: readCollection('invoices'),
+    expenses: readCollection('expenses'),
+    siteUpdates: readCollection('siteUpdates'),
+    projectMessages: readCollection('projectMessages'),
+    notifications: readCollection('notifications'),
+    quotes: readCollection('quotes'),
+    auditLogs: readCollection('auditLogs'),
+    resourceAssignments: readCollection('resourceAssignments'),
+    conversations: readCollection('conversations'),
+    messages: readCollection('messages'),
+    projectAssignments: readCollection('projectAssignments'),
+    projectTemplates: readCollection('projectTemplates'),
+    whiteboardNotes: readCollection('whiteboardNotes'),
+    documents: readCollection('documents'),
+    projectInsights: readCollection('projectInsights'),
+});
+
+let db: DbCollections = createDb();
+
 const saveDb = () => {
-    Object.entries(db).forEach(([key, value]) => {
-        localStorage.setItem(`asagents_${key}`, JSON.stringify(value));
+    (Object.keys(db) as Array<keyof DbCollections>).forEach(key => {
+        storage.setItem(`${STORAGE_PREFIX}${String(key)}`, JSON.stringify(db[key]));
     });
 };
+
+const findUserByEmail = (email: string) => {
+    const normalized = normalizeEmail(email);
+    return db.users.find(u => u.email && u.email.toLowerCase() === normalized);
+};
+
+const sanitizeUserForReturn = (user: Partial<User>): User => sanitizeUser(user) as User;
+
+const sanitizeUsersForReturn = (users: Partial<User>[]): User[] => users.map(u => sanitizeUserForReturn(u));
+
+const upgradeLegacyUsers = () => {
+    const legacyUsersToUpgrade = db.users.filter(u => u.password && (!u.passwordHash || !u.passwordSalt));
+    if (legacyUsersToUpgrade.length === 0) {
+        return;
+    }
+    Promise.all(legacyUsersToUpgrade.map(user => upgradeLegacyPassword(user as Partial<User>)))
+        .then(() => {
+            saveDb();
+        })
+        .catch(error => console.error('Failed to upgrade legacy user credentials', error));
+};
+
+upgradeLegacyUsers();
+
+const ensureUserPermissionConsistency = () => {
+    let updated = false;
+    db.users.forEach(user => {
+        if (user.role && (!user.permissions || (user.permissions as Permission[]).length === 0)) {
+            user.permissions = Array.from(RolePermissions[user.role]);
+            updated = true;
+        }
+    });
+    if (updated) {
+        saveDb();
+    }
+};
+
+ensureUserPermissionConsistency();
 
 const addAuditLog = (actorId: string, action: string, target?: { type: string, id: string, name: string }) => {
     const newLog: AuditLog = {
@@ -126,72 +300,212 @@ const addAuditLog = (actorId: string, action: string, target?: { type: string, i
         timestamp: new Date().toISOString(),
     };
     db.auditLogs.push(newLog);
+    saveDb();
 };
 
 export const authApi = {
-    register: async (credentials: Partial<RegisterCredentials & { companyName?: string; companyType?: CompanyType; companyEmail?: string; companyPhone?: string; companyWebsite?: string; companySelection?: 'create' | 'join', role?: Role }>): Promise<any> => {
+    register: async (credentials: RegistrationPayload): Promise<any> => {
         await delay();
-        if (db.users.some(u => u.email === credentials.email)) {
-            throw new Error("An account with this email already exists.");
+
+        if (!credentials.email || !credentials.password) {
+            throw new Error('Email and password are required.');
         }
 
+        if (!credentials.termsAccepted) {
+            throw new Error('You must accept the terms and conditions to create an account.');
+        }
+
+        const normalizedEmail = normalizeEmail(credentials.email);
+        if (findUserByEmail(normalizedEmail)) {
+            throw new Error('An account with this email already exists.');
+        }
+
+        const password = credentials.password.trim();
+        const passwordRequirements = [
+            password.length >= 8,
+            /[A-Z]/.test(password),
+            /[a-z]/.test(password),
+            /\d/.test(password),
+            /[^A-Za-z0-9]/.test(password),
+        ];
+        if (!passwordRequirements.every(Boolean)) {
+            throw new Error('Password does not meet the minimum complexity requirements.');
+        }
+
+        const firstName = credentials.firstName?.trim();
+        const lastName = credentials.lastName?.trim();
+        const phone = credentials.phone?.trim();
+
         let companyId: string;
+        let companyRecord: Partial<Company> | undefined;
         let userRole = credentials.role || Role.OPERATIVE;
 
         if (credentials.companySelection === 'create') {
-            const newCompany: Partial<Company> = {
-                id: String(Date.now()),
-                name: credentials.companyName,
-                type: credentials.companyType || 'GENERAL_CONTRACTOR',
-                email: credentials.companyEmail,
-                phone: credentials.companyPhone,
-                website: credentials.companyWebsite,
+            const companyName = credentials.companyName?.trim();
+            const companyType = credentials.companyType;
+            const companyEmail = credentials.companyEmail ? normalizeEmail(credentials.companyEmail) : undefined;
+            const companyPhone = credentials.companyPhone?.trim();
+            const companyWebsite = credentials.companyWebsite?.trim();
+
+            if (!companyName || !companyType) {
+                throw new Error('Company information is incomplete.');
+            }
+
+            const timestamp = String(Date.now());
+            companyId = timestamp;
+            companyRecord = {
+                id: companyId,
+                name: companyName,
+                type: companyType,
+                email: companyEmail,
+                phone: companyPhone,
+                website: companyWebsite,
                 status: 'Active',
                 subscriptionPlan: 'FREE',
                 storageUsageGB: 0,
+                settings: defaultCompanySettings(),
+                address: {
+                    street: '',
+                    city: '',
+                    state: '',
+                    zipCode: '',
+                    country: 'United Kingdom',
+                },
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
             };
-            db.companies.push(newCompany);
-            companyId = newCompany.id!;
+            db.companies.push(companyRecord);
+
+            inviteTokenDirectory.set(`JOIN-${companyId}`, {
+                companyId,
+                allowedRoles: [Role.ADMIN, Role.PROJECT_MANAGER, Role.FOREMAN, Role.OPERATIVE],
+                suggestedRole: Role.ADMIN,
+            });
+
             userRole = Role.OWNER;
         } else if (credentials.companySelection === 'join') {
-            if (credentials.inviteToken !== 'JOIN-CONSTRUCTCO') {
-                 throw new Error("Invalid invite token.");
+            const normalizedToken = credentials.inviteToken ? normalizeInviteToken(credentials.inviteToken) : '';
+            if (!normalizedToken) {
+                throw new Error('An invite token is required to join an existing company.');
             }
-            companyId = '1';
+            const inviteDetails = inviteTokenDirectory.get(normalizedToken);
+            if (!inviteDetails) {
+                throw new Error('Invalid invite token.');
+            }
+            companyId = inviteDetails.companyId;
+            companyRecord = db.companies.find(c => c.id === companyId);
+            if (!companyRecord) {
+                throw new Error('Company not found for invite token.');
+            }
+            if (credentials.role && !inviteDetails.allowedRoles.includes(credentials.role)) {
+                throw new Error('Selected role is not permitted for this invite.');
+            }
+            userRole = credentials.role && inviteDetails.allowedRoles.includes(credentials.role)
+                ? credentials.role
+                : inviteDetails.suggestedRole || inviteDetails.allowedRoles[0];
         } else {
-            throw new Error("Invalid company selection.");
+            throw new Error('Invalid company selection.');
         }
 
+        const passwordRecord = await createPasswordRecord(password);
+
+        const createdAt = new Date().toISOString();
         const newUser: Partial<User> = {
-            id: String(Date.now()),
-            firstName: credentials.firstName,
-            lastName: credentials.lastName,
-            email: credentials.email,
-            password: credentials.password,
-            phone: credentials.phone,
+            id: String(Date.now() + Math.random()),
+            firstName,
+            lastName,
+            email: normalizedEmail,
+            passwordHash: passwordRecord.hash,
+            passwordSalt: passwordRecord.salt,
+            phone,
             role: userRole,
+            permissions: Array.from(RolePermissions[userRole]),
             companyId,
             isActive: true,
-            isEmailVerified: true, // Mocking verification for simplicity
-            createdAt: new Date().toISOString(),
+            isEmailVerified: true,
+            mfaEnabled: false,
+            createdAt,
+            updatedAt: createdAt,
+            preferences: defaultUserPreferences(),
         };
+
+        if (credentials.updatesOptIn === false) {
+            newUser.preferences!.notifications.projectUpdates = false;
+        }
+
         db.users.push(newUser);
+
+        const resolvedCompany = companyRecord || db.companies.find(c => c.id === companyId);
+        if (resolvedCompany?.name) {
+            addAuditLog(newUser.id!, 'USER_REGISTERED', { type: 'Company', id: companyId, name: resolvedCompany.name });
+            if (credentials.companySelection === 'create') {
+                addAuditLog(newUser.id!, 'COMPANY_CREATED', { type: 'Company', id: companyId, name: resolvedCompany.name });
+            }
+        }
+
         saveDb();
 
-        const user = db.users.find(u => u.id === newUser.id) as User;
+        const user = db.users.find(u => u.id === newUser.id)!;
         const company = db.companies.find(c => c.id === companyId) as Company;
 
         const token = createToken({ userId: user.id, companyId: company.id, role: user.role }, MOCK_ACCESS_TOKEN_LIFESPAN);
         const refreshToken = createToken({ userId: user.id }, MOCK_REFRESH_TOKEN_LIFESPAN);
-        
-        return { success: true, token, refreshToken, user, company };
+
+        return { success: true, token, refreshToken, user: sanitizeUserForReturn(user), company };
+    },
+    checkEmailAvailability: async (email: string): Promise<{ available: boolean }> => {
+        await delay(120);
+        if (!email) {
+            return { available: false };
+        }
+        const normalized = normalizeEmail(email);
+        return { available: !findUserByEmail(normalized) };
+    },
+    lookupInviteToken: async (token: string): Promise<{ companyId: string; companyName: string; companyType?: CompanyType; allowedRoles: Role[]; suggestedRole?: Role }> => {
+        await delay(200);
+        if (!token) {
+            throw new Error('An invite token is required.');
+        }
+        const normalizedToken = normalizeInviteToken(token);
+        const details = inviteTokenDirectory.get(normalizedToken);
+        if (!details) {
+            throw new Error('Invite token not recognized.');
+        }
+        const company = db.companies.find(c => c.id === details.companyId);
+        if (!company) {
+            throw new Error('Company not found for invite token.');
+        }
+        return {
+            companyId: company.id!,
+            companyName: company.name || 'Unnamed Company',
+            companyType: company.type as CompanyType,
+            allowedRoles: details.allowedRoles,
+            suggestedRole: details.suggestedRole,
+        };
     },
     login: async (credentials: LoginCredentials): Promise<any> => {
         await delay(200);
-        const user = db.users.find(u => u.email === credentials.email && u.password === credentials.password);
+        const normalizedEmail = normalizeEmail(credentials.email);
+        const user = findUserByEmail(normalizedEmail);
         if (!user) {
             throw new Error("Invalid email or password.");
         }
+
+        const needsUpgrade = !!user.password && (!user.passwordHash || !user.passwordSalt);
+        if (needsUpgrade) {
+            await upgradeLegacyPassword(user as Partial<User>);
+            saveDb();
+        }
+
+        if (!user.passwordHash || !user.passwordSalt) {
+            throw new Error("Invalid email or password.");
+        }
+
+        const isValid = await verifyPassword(credentials.password, user.passwordHash, user.passwordSalt);
+        if (!isValid) {
+            throw new Error("Invalid email or password.");
+        }
+
         if (user.mfaEnabled) {
             return { success: true, mfaRequired: true, userId: user.id };
         }
@@ -206,15 +520,15 @@ export const authApi = {
     },
     finalizeLogin: async (userId: string): Promise<any> => {
         await delay();
-        const user = db.users.find(u => u.id === userId) as User;
+        const user = db.users.find(u => u.id === userId);
         if (!user) throw new Error("User not found during finalization.");
         const company = db.companies.find(c => c.id === user.companyId) as Company;
         if (!company) throw new Error("Company not found for user.");
 
-        const token = createToken({ userId: user.id, companyId: company.id, role: user.role }, MOCK_ACCESS_TOKEN_LIFESPAN);
-        const refreshToken = createToken({ userId: user.id }, MOCK_REFRESH_TOKEN_LIFESPAN);
-        
-        return { success: true, token, refreshToken, user, company };
+        const token = createToken({ userId: user.id!, companyId: company.id, role: user.role }, MOCK_ACCESS_TOKEN_LIFESPAN);
+        const refreshToken = createToken({ userId: user.id! }, MOCK_REFRESH_TOKEN_LIFESPAN);
+
+        return { success: true, token, refreshToken, user: sanitizeUserForReturn(user), company };
     },
     refreshToken: async (refreshToken: string): Promise<{ token: string }> => {
         await delay();
@@ -234,14 +548,14 @@ export const authApi = {
         await delay();
         const decoded = decodeToken(token);
         if (!decoded) throw new Error("Invalid or expired token");
-        const user = db.users.find(u => u.id === decoded.userId) as User;
+        const user = db.users.find(u => u.id === decoded.userId);
         const company = db.companies.find(c => c.id === decoded.companyId) as Company;
         if (!user || !company) throw new Error("User or company not found");
-        return { user, company };
+        return { user: sanitizeUserForReturn(user), company };
     },
     requestPasswordReset: async (email: string): Promise<{ success: boolean }> => {
         await delay(300);
-        const user = db.users.find(u => u.email === email);
+        const user = email ? findUserByEmail(email) : undefined;
         if (user) {
             const token = `reset-${Date.now()}-${Math.random()}`;
             passwordResetTokens.set(token, { userId: user.id!, expires: Date.now() + MOCK_RESET_TOKEN_LIFESPAN });
@@ -260,7 +574,10 @@ export const authApi = {
         if (userIndex === -1) {
             throw new Error("User not found.");
         }
-        db.users[userIndex].password = newPassword;
+        const passwordRecord = await createPasswordRecord(newPassword);
+        db.users[userIndex].passwordHash = passwordRecord.hash;
+        db.users[userIndex].passwordSalt = passwordRecord.salt;
+        delete db.users[userIndex].password;
         saveDb();
         passwordResetTokens.delete(token);
         return { success: true };
@@ -268,12 +585,12 @@ export const authApi = {
 };
 
 type OfflineAction = { id: number, type: string, payload: any, retries: number, error?: string };
-let offlineQueue: OfflineAction[] = JSON.parse(localStorage.getItem('asagents_offline_queue') || '[]');
-let failedSyncActions: OfflineAction[] = JSON.parse(localStorage.getItem('asagents_failed_sync_actions') || '[]');
+let offlineQueue: OfflineAction[] = readJson<OfflineAction[]>('asagents_offline_queue', []);
+let failedSyncActions: OfflineAction[] = readJson<OfflineAction[]>('asagents_failed_sync_actions', []);
 
 const saveQueues = () => {
-    localStorage.setItem('asagents_offline_queue', JSON.stringify(offlineQueue));
-    localStorage.setItem('asagents_failed_sync_actions', JSON.stringify(failedSyncActions));
+    writeJson('asagents_offline_queue', offlineQueue);
+    writeJson('asagents_failed_sync_actions', failedSyncActions);
 };
 
 const addToOfflineQueue = (type: string, payload: any) => {
@@ -331,6 +648,22 @@ export const formatFailedActionForUI = (action: OfflineAction): FailedActionForU
     error: action.error || 'Unknown Error',
     timestamp: new Date(action.id).toLocaleString(),
 });
+
+export const resetMockApi = () => {
+    (Object.keys(DEFAULT_COLLECTIONS) as Array<keyof DbCollections>).forEach(key => {
+        const defaults = clone(DEFAULT_COLLECTIONS[key]);
+        writeJson(`${STORAGE_PREFIX}${String(key)}`, defaults);
+    });
+
+    db = createDb();
+    offlineQueue = [];
+    failedSyncActions = [];
+    writeJson('asagents_offline_queue', offlineQueue);
+    writeJson('asagents_failed_sync_actions', failedSyncActions);
+    passwordResetTokens.clear();
+    resetInviteTokens();
+    upgradeLegacyUsers();
+};
 
 export const api = {
     getCompanySettings: async (companyId: string): Promise<CompanySettings> => {
@@ -401,7 +734,7 @@ export const api = {
         ensureNotAborted(options?.signal);
         await delay();
         ensureNotAborted(options?.signal);
-        return db.users.filter(u => u.companyId === companyId) as User[];
+        return sanitizeUsersForReturn(db.users.filter(u => u.companyId === companyId));
     },
     getEquipmentByCompany: async (companyId: string, options?: RequestOptions): Promise<Equipment[]> => {
         ensureNotAborted(options?.signal);
@@ -440,7 +773,7 @@ export const api = {
         ensureNotAborted(options?.signal);
         const assignments = db.projectAssignments.filter(pa => pa.projectId === projectId);
         const userIds = new Set(assignments.map(a => a.userId));
-        return db.users.filter(u => userIds.has(u.id!)) as User[];
+        return sanitizeUsersForReturn(db.users.filter(u => userIds.has(u.id!)));
     },
     getProjectInsights: async (projectId: string, options?: RequestOptions): Promise<ProjectInsight[]> => {
         ensureNotAborted(options?.signal);
@@ -856,27 +1189,56 @@ export const api = {
         return { totalHours: 120, tasksCompleted: 15 };
     },
     createUser: async (data: any, userId: string): Promise<User> => {
-        const newUser = { ...data, id: String(Date.now()), companyId: db.users.find(u=>u.id===userId)?.companyId };
+        const newUser: Partial<User> = {
+            ...data,
+            id: String(Date.now()),
+            companyId: db.users.find(u => u.id === userId)?.companyId,
+        };
+
+        if (newUser.email) {
+            newUser.email = normalizeEmail(newUser.email);
+        }
+
+        if (data?.password) {
+            const passwordRecord = await createPasswordRecord(data.password);
+            newUser.passwordHash = passwordRecord.hash;
+            newUser.passwordSalt = passwordRecord.salt;
+            delete (newUser as any).password;
+        }
+
         db.users.push(newUser);
         saveDb();
-        return newUser as User;
+        return sanitizeUserForReturn(newUser);
     },
     updateUser: async (id: string, data: Partial<User>, projectIds: (string|number)[] | undefined, userId: string): Promise<User> => {
-        const index = db.users.findIndex(u=>u.id === id);
+        const index = db.users.findIndex(u => u.id === id);
         if (index === -1) throw new Error("User not found");
-        
-        // Merge existing user data with updates
-        db.users[index] = { ...db.users[index], ...data };
-        
+
+        const updates: Partial<User> = { ...data };
+
+        if (updates.email) {
+            updates.email = normalizeEmail(updates.email);
+        }
+
+        if ((data as any)?.password) {
+            const passwordRecord = await createPasswordRecord((data as any).password);
+            updates.passwordHash = passwordRecord.hash;
+            updates.passwordSalt = passwordRecord.salt;
+            delete (updates as any).password;
+        }
+
+        db.users[index] = { ...db.users[index], ...updates };
+        delete (db.users[index] as any).password;
+
         // Only update project assignments if the projectIds array is explicitly passed
         // This allows for profile-only updates by omitting the projectIds argument
         if (projectIds !== undefined) {
             db.projectAssignments = db.projectAssignments.filter(pa => pa.userId !== id);
-            projectIds.forEach(pid => db.projectAssignments.push({userId: id, projectId: String(pid)}));
+            projectIds.forEach(pid => db.projectAssignments.push({ userId: id, projectId: String(pid) }));
         }
-        
+
         saveDb();
-        return db.users[index] as User;
+        return sanitizeUserForReturn(db.users[index]);
     },
     prioritizeTasks: async (tasks: Todo[], projects: Project[], userId: string): Promise<{prioritizedTaskIds: string[]}> => {
         await delay(1000);

--- a/types.ts
+++ b/types.ts
@@ -26,6 +26,19 @@ export interface RegisterCredentials {
   inviteToken?: string;
 }
 
+export type RegistrationPayload = Partial<RegisterCredentials & {
+  companyName?: string;
+  companyType?: CompanyType;
+  companyEmail?: string;
+  companyPhone?: string;
+  companyWebsite?: string;
+  companySelection?: 'create' | 'join';
+  inviteToken?: string;
+  role?: Role;
+  updatesOptIn?: boolean;
+  termsAccepted?: boolean;
+}>;
+
 export interface Company {
   id: string;
   name: string;
@@ -93,6 +106,8 @@ export interface User {
   lastName: string;
   email: string;
   password?: string;
+  passwordHash?: string;
+  passwordSalt?: string;
   mfaEnabled?: boolean;
   phone?: string;
   avatar?: string;

--- a/utils/authRememberMe.ts
+++ b/utils/authRememberMe.ts
@@ -1,0 +1,39 @@
+import { getStorage } from './storage';
+
+const REMEMBERED_EMAIL_KEY = 'asagents_remembered_email';
+
+const storage = getStorage();
+
+const normalizeEmail = (email: string) => email.trim().toLowerCase();
+
+export const readRememberedEmail = (): string => {
+    try {
+        return storage.getItem(REMEMBERED_EMAIL_KEY) || '';
+    } catch (error) {
+        console.warn('Unable to read remembered email', error);
+        return '';
+    }
+};
+
+export const persistRememberedEmail = (shouldRemember: boolean, email: string) => {
+    try {
+        if (shouldRemember && email) {
+            storage.setItem(REMEMBERED_EMAIL_KEY, normalizeEmail(email));
+        } else {
+            storage.removeItem(REMEMBERED_EMAIL_KEY);
+        }
+    } catch (error) {
+        console.warn('Unable to persist remembered email', error);
+    }
+};
+
+export const clearRememberedEmail = () => {
+    try {
+        storage.removeItem(REMEMBERED_EMAIL_KEY);
+    } catch (error) {
+        console.warn('Unable to clear remembered email', error);
+    }
+};
+
+export const REMEMBERED_EMAIL_STORAGE_KEY = REMEMBERED_EMAIL_KEY;
+

--- a/utils/password.ts
+++ b/utils/password.ts
@@ -1,0 +1,67 @@
+import { User } from '../types';
+
+const getCrypto = (): Crypto => {
+    if (typeof globalThis.crypto !== 'undefined') {
+        return globalThis.crypto as Crypto;
+    }
+    throw new Error('Secure crypto APIs are not available in this environment.');
+};
+
+const cryptoApi = getCrypto();
+const encoder = new TextEncoder();
+
+const toHex = (buffer: ArrayBuffer): string =>
+    Array.from(new Uint8Array(buffer))
+        .map(byte => byte.toString(16).padStart(2, '0'))
+        .join('');
+
+const generateSalt = (length = 16): string => {
+    const bytes = new Uint8Array(length);
+    cryptoApi.getRandomValues(bytes);
+    return toHex(bytes.buffer);
+};
+
+const deriveHash = async (password: string, salt: string): Promise<string> => {
+    const data = encoder.encode(`${salt}:${password}`);
+    const digest = await cryptoApi.subtle.digest('SHA-256', data);
+    return toHex(digest);
+};
+
+const timingSafeEqual = (a: string, b: string): boolean => {
+    if (a.length !== b.length) {
+        return false;
+    }
+    let result = 0;
+    for (let i = 0; i < a.length; i++) {
+        result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    }
+    return result === 0;
+};
+
+export const createPasswordRecord = async (password: string): Promise<{ hash: string; salt: string }> => {
+    const salt = generateSalt();
+    const hash = await deriveHash(password, salt);
+    return { hash, salt };
+};
+
+export const verifyPassword = async (password: string, hash: string, salt: string): Promise<boolean> => {
+    const derivedHash = await deriveHash(password, salt);
+    return timingSafeEqual(derivedHash, hash);
+};
+
+export const upgradeLegacyPassword = async <T extends Partial<User> & { password?: string; passwordHash?: string; passwordSalt?: string }>(
+    user: T
+): Promise<T> => {
+    if (!user.passwordHash && !user.passwordSalt && user.password) {
+        const { hash, salt } = await createPasswordRecord(user.password);
+        user.passwordHash = hash;
+        user.passwordSalt = salt;
+        delete user.password;
+    }
+    return user;
+};
+
+export const sanitizeUser = <T extends Partial<User>>(user: T): T => {
+    const { password, passwordHash, passwordSalt, ...rest } = user;
+    return rest as T;
+};

--- a/utils/registrationDraft.test.ts
+++ b/utils/registrationDraft.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    loadRegistrationDraft,
+    saveRegistrationDraft,
+    clearRegistrationDraft,
+    registrationDraftHasContent,
+    EMPTY_REGISTRATION_DRAFT,
+    REGISTRATION_DRAFT_TTL_MS,
+} from './registrationDraft';
+import { resetInMemoryStorage } from './storage';
+import { Role } from '../types';
+
+describe('registrationDraft storage helpers', () => {
+    beforeEach(() => {
+        resetInMemoryStorage();
+        clearRegistrationDraft();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2024-01-01T08:00:00Z'));
+    });
+
+    afterEach(() => {
+        clearRegistrationDraft();
+        vi.useRealTimers();
+    });
+
+    it('persists sanitized values and restores them', () => {
+        saveRegistrationDraft({
+            step: 'workspace',
+            firstName: '  Ada  ',
+            lastName: ' Lovelace ',
+            email: ' ada@example.com ',
+            phone: ' +44 123 456 789 ',
+            companySelection: 'join',
+            companyName: ' Example Builders ',
+            companyType: 'GENERAL_CONTRACTOR',
+            companyEmail: ' TEAM@example.com ',
+            companyPhone: '0200 000 000',
+            companyWebsite: ' https://example.com ',
+            inviteToken: ' join-code ',
+            role: Role.PROJECT_MANAGER,
+            updatesOptIn: false,
+            termsAccepted: true,
+        });
+
+        const draft = loadRegistrationDraft();
+        expect(draft).toEqual({
+            step: 'workspace',
+            firstName: 'Ada',
+            lastName: 'Lovelace',
+            email: 'ada@example.com',
+            phone: '+44 123 456 789',
+            companySelection: 'join',
+            companyName: 'Example Builders',
+            companyType: 'GENERAL_CONTRACTOR',
+            companyEmail: 'TEAM@example.com',
+            companyPhone: '0200 000 000',
+            companyWebsite: 'https://example.com',
+            inviteToken: 'join-code',
+            role: Role.PROJECT_MANAGER,
+            updatesOptIn: false,
+            termsAccepted: true,
+        });
+    });
+
+    it('does not persist drafts without meaningful content', () => {
+        expect(registrationDraftHasContent(EMPTY_REGISTRATION_DRAFT)).toBe(false);
+        saveRegistrationDraft({});
+        expect(loadRegistrationDraft()).toBeNull();
+    });
+
+    it('expires drafts after the configured TTL', () => {
+        saveRegistrationDraft({
+            step: 'confirm',
+            firstName: 'Nora',
+            lastName: 'Stone',
+            email: 'nora@example.com',
+            companySelection: 'create',
+            companyName: 'Stoneworks',
+            companyType: 'SUPPLIER',
+            termsAccepted: true,
+        });
+
+        vi.setSystemTime(Date.now() + REGISTRATION_DRAFT_TTL_MS + 1000);
+        expect(loadRegistrationDraft()).toBeNull();
+    });
+
+    it('sanitizes invalid values on save', () => {
+        saveRegistrationDraft({
+            step: 'unknown' as any,
+            companySelection: 'invalid' as any,
+            companyType: 'NOT_A_TYPE' as any,
+            role: 'NOT_A_ROLE' as any,
+            termsAccepted: 'yes' as any,
+        });
+
+        expect(loadRegistrationDraft()).toBeNull();
+    });
+});
+

--- a/utils/registrationDraft.ts
+++ b/utils/registrationDraft.ts
@@ -1,0 +1,186 @@
+import { CompanyType, Role } from '../types';
+import { getStorage } from './storage';
+
+export type RegistrationStep = 'account' | 'workspace' | 'confirm';
+
+export interface RegistrationDraft {
+    step: RegistrationStep;
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone: string;
+    companySelection: '' | 'create' | 'join';
+    companyName: string;
+    companyType: CompanyType | '';
+    companyEmail: string;
+    companyPhone: string;
+    companyWebsite: string;
+    inviteToken: string;
+    role: Role | '';
+    updatesOptIn: boolean;
+    termsAccepted: boolean;
+}
+
+type PersistedDraft = {
+    version: 1;
+    savedAt: number;
+    expiresAt: number;
+    data: RegistrationDraft;
+};
+
+const REGISTRATION_DRAFT_KEY = 'asagents_registration_draft_v1';
+
+const COMPANY_TYPES: CompanyType[] = [
+    'GENERAL_CONTRACTOR',
+    'SUBCONTRACTOR',
+    'SUPPLIER',
+    'CONSULTANT',
+    'CLIENT',
+];
+
+const ROLE_VALUES = new Set(Object.values(Role));
+
+const storage = getStorage();
+
+export const REGISTRATION_DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export const EMPTY_REGISTRATION_DRAFT: RegistrationDraft = {
+    step: 'account',
+    firstName: '',
+    lastName: '',
+    email: '',
+    phone: '',
+    companySelection: '',
+    companyName: '',
+    companyType: '',
+    companyEmail: '',
+    companyPhone: '',
+    companyWebsite: '',
+    inviteToken: '',
+    role: '',
+    updatesOptIn: true,
+    termsAccepted: false,
+};
+
+const sanitizeStep = (value: unknown): RegistrationStep => {
+    if (value === 'workspace' || value === 'confirm') {
+        return value;
+    }
+    return 'account';
+};
+
+const sanitizeString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+const sanitizeCompanySelection = (value: unknown): RegistrationDraft['companySelection'] => {
+    if (value === 'create' || value === 'join') {
+        return value;
+    }
+    return '';
+};
+
+const sanitizeCompanyType = (value: unknown): RegistrationDraft['companyType'] => {
+    if (typeof value === 'string' && (COMPANY_TYPES as string[]).includes(value)) {
+        return value as CompanyType;
+    }
+    return '';
+};
+
+const sanitizeRole = (value: unknown): RegistrationDraft['role'] => {
+    if (typeof value === 'string' && ROLE_VALUES.has(value as Role)) {
+        return value as Role;
+    }
+    return '';
+};
+
+const sanitizeBoolean = (value: unknown, fallback: boolean) => (typeof value === 'boolean' ? value : fallback);
+
+const sanitizeDraft = (draft: Partial<RegistrationDraft>): RegistrationDraft => ({
+    step: sanitizeStep(draft.step),
+    firstName: sanitizeString(draft.firstName),
+    lastName: sanitizeString(draft.lastName),
+    email: sanitizeString(draft.email),
+    phone: sanitizeString(draft.phone),
+    companySelection: sanitizeCompanySelection(draft.companySelection),
+    companyName: sanitizeString(draft.companyName),
+    companyType: sanitizeCompanyType(draft.companyType),
+    companyEmail: sanitizeString(draft.companyEmail),
+    companyPhone: sanitizeString(draft.companyPhone),
+    companyWebsite: sanitizeString(draft.companyWebsite),
+    inviteToken: sanitizeString(draft.inviteToken),
+    role: sanitizeRole(draft.role),
+    updatesOptIn: sanitizeBoolean(draft.updatesOptIn, true),
+    termsAccepted: sanitizeBoolean(draft.termsAccepted, false),
+});
+
+const draftsDiffer = (a: RegistrationDraft, b: RegistrationDraft) =>
+    a.step !== b.step ||
+    a.firstName !== b.firstName ||
+    a.lastName !== b.lastName ||
+    a.email !== b.email ||
+    a.phone !== b.phone ||
+    a.companySelection !== b.companySelection ||
+    a.companyName !== b.companyName ||
+    a.companyType !== b.companyType ||
+    a.companyEmail !== b.companyEmail ||
+    a.companyPhone !== b.companyPhone ||
+    a.companyWebsite !== b.companyWebsite ||
+    a.inviteToken !== b.inviteToken ||
+    a.role !== b.role ||
+    a.updatesOptIn !== b.updatesOptIn ||
+    a.termsAccepted !== b.termsAccepted;
+
+export const registrationDraftHasContent = (draft: RegistrationDraft): boolean =>
+    draftsDiffer(draft, EMPTY_REGISTRATION_DRAFT);
+
+export const saveRegistrationDraft = (input: Partial<RegistrationDraft>) => {
+    const sanitized = sanitizeDraft(input);
+    if (!registrationDraftHasContent(sanitized)) {
+        clearRegistrationDraft();
+        return;
+    }
+
+    const payload: PersistedDraft = {
+        version: 1,
+        savedAt: Date.now(),
+        expiresAt: Date.now() + REGISTRATION_DRAFT_TTL_MS,
+        data: sanitized,
+    };
+
+    try {
+        storage.setItem(REGISTRATION_DRAFT_KEY, JSON.stringify(payload));
+    } catch (error) {
+        console.warn('Unable to persist registration draft', error);
+    }
+};
+
+export const loadRegistrationDraft = (): RegistrationDraft | null => {
+    try {
+        const raw = storage.getItem(REGISTRATION_DRAFT_KEY);
+        if (!raw) {
+            return null;
+        }
+        const parsed = JSON.parse(raw) as PersistedDraft | undefined;
+        if (!parsed || typeof parsed !== 'object' || parsed.version !== 1) {
+            clearRegistrationDraft();
+            return null;
+        }
+        if (typeof parsed.expiresAt === 'number' && parsed.expiresAt < Date.now()) {
+            clearRegistrationDraft();
+            return null;
+        }
+        return sanitizeDraft(parsed.data);
+    } catch (error) {
+        console.warn('Unable to read registration draft', error);
+        clearRegistrationDraft();
+        return null;
+    }
+};
+
+export const clearRegistrationDraft = () => {
+    try {
+        storage.removeItem(REGISTRATION_DRAFT_KEY);
+    } catch (error) {
+        console.warn('Unable to clear registration draft', error);
+    }
+};
+

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,0 +1,69 @@
+export interface StorageLike {
+    getItem(key: string): string | null;
+    setItem(key: string, value: string): void;
+    removeItem(key: string): void;
+    clear(): void;
+    key(index: number): string | null;
+    readonly length: number;
+}
+
+const createMemoryStorage = (): StorageLike => {
+    const store = new Map<string, string>();
+    return {
+        getItem(key: string) {
+            return store.has(key) ? store.get(key)! : null;
+        },
+        setItem(key: string, value: string) {
+            store.set(key, String(value));
+        },
+        removeItem(key: string) {
+            store.delete(key);
+        },
+        clear() {
+            store.clear();
+        },
+        key(index: number) {
+            return Array.from(store.keys())[index] ?? null;
+        },
+        get length() {
+            return store.size;
+        },
+    };
+};
+
+let cachedStorage: StorageLike | null = null;
+
+export const getStorage = (): StorageLike => {
+    if (cachedStorage) {
+        return cachedStorage;
+    }
+
+    try {
+        const globalScope = globalThis as unknown as { localStorage?: StorageLike };
+        if (globalScope && globalScope.localStorage) {
+            const testKey = '__asagents_storage_test__';
+            globalScope.localStorage.setItem(testKey, '1');
+            globalScope.localStorage.removeItem(testKey);
+            cachedStorage = globalScope.localStorage;
+            return cachedStorage;
+        }
+    } catch (error) {
+        console.warn('Falling back to in-memory storage adapter.', error);
+    }
+
+    cachedStorage = createMemoryStorage();
+    return cachedStorage;
+};
+
+export const resetInMemoryStorage = () => {
+    if (!cachedStorage) {
+        return;
+    }
+
+    const globalScope = globalThis as unknown as { localStorage?: StorageLike };
+    if (globalScope.localStorage && cachedStorage === globalScope.localStorage) {
+        return; // do not clear the real browser storage implicitly
+    }
+
+    cachedStorage.clear();
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "devCommand": "npm run dev -- --host 0.0.0.0 --port 4173",
+  "env": {
+    "VITE_GEMINI_API_KEY": "@gemini_api_key",
+    "GEMINI_API_KEY": "@gemini_api_key"
+  },
+  "preview": {
+    "env": {
+      "VITE_API_BASE_URL": "@preview_api_base_url"
+    }
+  },
+  "production": {
+    "env": {
+      "VITE_API_BASE_URL": "@production_api_base_url"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a runtime-configurable authentication client that can call a real backend with graceful fallback to the encrypted mock API
- update the auth provider, registration flow, and shared auth screens to surface the current auth environment and reuse the new client
- document backend configuration options and cover the client with Vitest fallback tests

## Testing
- npm run test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc9a1646dc8327afa6be81212d89cd