### PR TITLE
Add backend gateway service and integrate dashboard snapshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,55 @@
         "use-supercluster": "0.4.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.8.0",
         "@types/node": "^22.14.0",
+        "jsdom": "^27.0.0",
+        "terser": "^5.44.0",
         "typescript": "~5.8.2",
         "vite": "^6.2.0",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.4.tgz",
+      "integrity": "sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.5.tgz",
+      "integrity": "sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
@@ -31,6 +75,144 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -496,12 +678,55 @@
         }
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@react-leaflet/core": {
       "version": "2.1.0",
@@ -808,6 +1033,26 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -957,6 +1202,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -964,6 +1222,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/assertion-error": {
@@ -996,6 +1264,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -1010,6 +1288,13 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1048,6 +1333,100 @@
         "node": ">= 16"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
+      "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -1075,6 +1454,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1094,6 +1480,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1101,6 +1494,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1280,6 +1686,33 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -1292,6 +1725,36 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -1310,6 +1773,83 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
@@ -1373,6 +1913,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -1381,6 +1931,23 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -1426,6 +1993,19 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -1494,6 +2074,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -1531,6 +2121,30 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -1574,6 +2188,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1594,6 +2215,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1610,6 +2251,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1618,6 +2269,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stackback": {
@@ -1633,6 +2295,19 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-literal": {
       "version": "3.0.0",
@@ -1662,6 +2337,32 @@
       "peer": true,
       "dependencies": {
         "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/terser": {
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
+      "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/tinybench": {
@@ -1723,6 +2424,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.15.tgz",
+      "integrity": "sha512-heYRCiGLhtI+U/D0V8YM3QRwPfsLJiP+HX+YwiHZTnWzjIKC+ZCxQRYlzvOoTEc6KIP62B1VeAN63diGCng2hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.15"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.15.tgz",
+      "integrity": "sha512-YBkp2VfS9VTRMPNL2PA6PMESmxV1JEVoAr5iBlZnB5JG3KUrWzNCB3yNNkRa2FZkqClaBgfNYCp8PgpYmpjkZw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -1967,11 +2701,47 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -2020,6 +2790,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "use-supercluster": "0.4.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.8.0",
     "@types/node": "^22.14.0",
+    "jsdom": "^27.0.0",
+    "terser": "^5.44.0",
     "typescript": "~5.8.2",
     "vite": "^6.2.0",
     "vitest": "^3.2.4"

--- a/services/__tests__/backendGateway.test.ts
+++ b/services/__tests__/backendGateway.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../analyticsService', () => ({
+    analytics: {
+        track: vi.fn(),
+        identify: vi.fn(),
+        flush: vi.fn(),
+    },
+}));
+
+vi.mock('../authClient', () => {
+    const subscribers = new Set<() => void>();
+    return {
+        getAuthConnectionInfo: () => ({
+            mode: 'mock' as const,
+            baseUrl: null,
+            baseHost: null,
+            allowMockFallback: true,
+        }),
+        subscribeToAuthClientChanges: (listener: () => void) => {
+            subscribers.add(listener);
+            return () => subscribers.delete(listener);
+        },
+    };
+});
+
+import { backendGateway } from '../backendGateway';
+import { apiCache } from '../cacheService';
+
+describe('backendGateway', () => {
+    beforeEach(() => {
+        apiCache.clear();
+        backendGateway.clearInteractionQueue();
+    });
+
+    it('returns a dashboard snapshot using local mock data when backend is unavailable', async () => {
+        const snapshot = await backendGateway.getDashboardSnapshot({
+            userId: '1',
+            companyId: '1',
+        });
+
+        expect(Array.isArray(snapshot.projects)).toBe(true);
+        expect(snapshot.metadata.source).toBe('mock');
+        expect(snapshot.metadata.usedFallback).toBe(true);
+    });
+
+    it('queues interactions when backend is unavailable', async () => {
+        const initialState = backendGateway.getState();
+
+        await backendGateway.recordInteraction({
+            type: 'test-event',
+            userId: '1',
+            companyId: '1',
+        });
+
+        const nextState = backendGateway.getState();
+        expect(nextState.pendingMutations).toBe(initialState.pendingMutations + 1);
+    });
+});

--- a/services/backendGateway.ts
+++ b/services/backendGateway.ts
@@ -1,0 +1,565 @@
+import { api } from './mockApi';
+import { analytics } from './analyticsService';
+import { apiCache } from './cacheService';
+import { getStorage } from '../utils/storage';
+import { computeProjectPortfolioSummary } from '../utils/projectPortfolio';
+import { ApiError } from './apiErrorHandler';
+import { getAuthConnectionInfo, subscribeToAuthClientChanges } from './authClient';
+import type {
+    BackendConnectionState,
+    BackendInteractionEvent,
+    DashboardSnapshot,
+    Project,
+    User,
+    Equipment,
+    Todo,
+    AuditLog,
+    SafetyIncident,
+    Expense,
+    OperationalInsights,
+    ResourceAssignment,
+} from '../types';
+import { Role } from '../types';
+
+type SnapshotParams = {
+    userId: string;
+    companyId: string;
+    signal?: AbortSignal;
+    forceRefresh?: boolean;
+};
+
+type QueuedInteraction = BackendInteractionEvent & {
+    id: string;
+    attempts: number;
+    lastError?: string;
+};
+
+const QUEUE_STORAGE_KEY = 'asagents:backend:interaction-queue:v1';
+const DASHBOARD_CACHE_TTL = 60 * 1000; // 1 minute
+
+const isAbortError = (error: unknown): boolean =>
+    error instanceof DOMException && error.name === 'AbortError';
+
+const normaliseStatus = (status: unknown): string =>
+    typeof status === 'string' ? status.toUpperCase() : '';
+
+const asStringId = (value: unknown): string | null => {
+    if (value == null) {
+        return null;
+    }
+    return String(value);
+};
+
+class BackendGateway {
+    private static instance: BackendGateway;
+
+    private connectionInfo = getAuthConnectionInfo();
+    private state: BackendConnectionState = {
+        mode: this.connectionInfo.mode,
+        baseUrl: this.connectionInfo.baseUrl,
+        online: typeof navigator === 'undefined' ? true : navigator.onLine,
+        pendingMutations: 0,
+        lastSync: null,
+    };
+    private readonly listeners = new Set<(state: BackendConnectionState) => void>();
+    private readonly storage = getStorage();
+    private queue: QueuedInteraction[];
+    private syncingQueue = false;
+
+    private constructor() {
+        this.queue = this.loadQueue();
+        this.state.pendingMutations = this.queue.length;
+
+        if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+            window.addEventListener('online', this.handleOnline);
+            window.addEventListener('offline', this.handleOffline);
+        }
+
+        subscribeToAuthClientChanges(() => this.refreshConnectionInfo());
+
+        if (this.state.online && this.connectionInfo.mode === 'backend') {
+            void this.syncQueuedInteractions();
+        }
+    }
+
+    static getInstance(): BackendGateway {
+        if (!BackendGateway.instance) {
+            BackendGateway.instance = new BackendGateway();
+        }
+        return BackendGateway.instance;
+    }
+
+    getState(): BackendConnectionState {
+        return { ...this.state };
+    }
+
+    subscribe(listener: (state: BackendConnectionState) => void): () => void {
+        this.listeners.add(listener);
+        try {
+            listener({ ...this.state });
+        } catch (error) {
+            console.error('[backendGateway] listener threw during initial emit', error);
+        }
+        return () => {
+            this.listeners.delete(listener);
+        };
+    }
+
+    async getDashboardSnapshot(params: SnapshotParams): Promise<DashboardSnapshot> {
+        const { userId, companyId, signal, forceRefresh = false } = params;
+
+        if (!userId || !companyId) {
+            throw new Error('Both userId and companyId are required to load dashboard data.');
+        }
+
+        const cacheKey = `dashboard:snapshot:${companyId}:${userId}`;
+        if (!forceRefresh) {
+            const cached = apiCache.get<DashboardSnapshot>(cacheKey);
+            if (cached) {
+                return { ...cached, metadata: { ...cached.metadata } };
+            }
+        }
+
+        let snapshot: DashboardSnapshot | null = null;
+        let usedBackend = false;
+
+        if (this.connectionInfo.mode === 'backend' && this.connectionInfo.baseUrl && this.state.online) {
+            try {
+                const query = new URLSearchParams({ companyId, userId }).toString();
+                const remote = await this.fetchFromBackend<Partial<DashboardSnapshot>>(
+                    `/app/dashboard/snapshot?${query}`,
+                    { method: 'GET', signal },
+                );
+
+                if (remote && Array.isArray(remote.projects)) {
+                    const metadata = {
+                        projectCount: Array.isArray(remote.projects) ? remote.projects.length : undefined,
+                        ...remote.metadata,
+                        source: 'backend' as const,
+                        generatedAt: remote.metadata?.generatedAt ?? new Date().toISOString(),
+                        usedFallback: false,
+                    };
+
+                    snapshot = {
+                        projects: remote.projects as Project[],
+                        team: (remote.team ?? []) as User[],
+                        equipment: (remote.equipment ?? []) as Equipment[],
+                        tasks: (remote.tasks ?? []) as Todo[],
+                        activityLog: (remote.activityLog ?? []) as AuditLog[],
+                        operationalInsights: (remote.operationalInsights ?? null) as OperationalInsights | null,
+                        incidents: (remote.incidents ?? []) as SafetyIncident[],
+                        expenses: (remote.expenses ?? []) as Expense[],
+                        portfolioSummary: remote.portfolioSummary ?? computeProjectPortfolioSummary(remote.projects as Project[]),
+                        metadata,
+                    };
+
+                    usedBackend = true;
+                }
+            } catch (error) {
+                if (isAbortError(error)) {
+                    throw error;
+                }
+                console.warn('[backendGateway] backend snapshot fetch failed, using local data instead.', error);
+            }
+        }
+
+        if (!snapshot) {
+            snapshot = await this.buildLocalSnapshot({ userId, companyId, signal });
+        }
+
+        const existingMetadata = snapshot.metadata ?? {};
+        snapshot.metadata = {
+            ...existingMetadata,
+            projectCount: existingMetadata.projectCount ?? snapshot.projects.length,
+            generatedAt: existingMetadata.generatedAt ?? new Date().toISOString(),
+            source: usedBackend ? 'backend' : 'mock',
+            usedFallback: usedBackend ? existingMetadata.usedFallback ?? false : true,
+        };
+
+        apiCache.set(cacheKey, snapshot, DASHBOARD_CACHE_TTL);
+        this.setState({ lastSync: snapshot.metadata.generatedAt });
+
+        try {
+            analytics.track?.('dashboard_snapshot_loaded', {
+                source: snapshot.metadata.source,
+                project_count: snapshot.metadata.projectCount,
+                used_fallback: snapshot.metadata.usedFallback,
+            });
+        } catch (error) {
+            console.warn('[backendGateway] analytics tracking failed', error);
+        }
+
+        return snapshot;
+    }
+
+    async recordInteraction(event: BackendInteractionEvent): Promise<void> {
+        const enriched: QueuedInteraction = {
+            ...event,
+            id: event.id ?? this.generateId(),
+            createdAt: event.createdAt ?? new Date().toISOString(),
+            attempts: 0,
+        };
+
+        if (this.connectionInfo.mode === 'backend' && this.connectionInfo.baseUrl && this.state.online) {
+            try {
+                await this.sendInteractionToBackend(enriched);
+                this.setState({ lastSync: enriched.createdAt ?? new Date().toISOString() });
+                analytics.track?.('backend_interaction_sent', {
+                    type: enriched.type,
+                    queued: false,
+                });
+                return;
+            } catch (error) {
+                if (isAbortError(error)) {
+                    throw error;
+                }
+                console.warn('[backendGateway] failed to deliver interaction, queueing for retry', error);
+            }
+        }
+
+        this.queue.push({ ...enriched });
+        this.enforceQueueLimit();
+        this.persistQueue();
+        this.setState({ pendingMutations: this.queue.length });
+
+        analytics.track?.('backend_interaction_queued', {
+            type: enriched.type,
+            pending: this.queue.length,
+        });
+
+        if (this.connectionInfo.mode === 'backend' && this.connectionInfo.baseUrl && this.state.online) {
+            void this.syncQueuedInteractions();
+        }
+    }
+
+    clearInteractionQueue(): void {
+        this.queue = [];
+        this.persistQueue();
+        this.setState({ pendingMutations: 0 });
+    }
+
+    private async buildLocalSnapshot(params: SnapshotParams): Promise<DashboardSnapshot> {
+        const { userId, companyId, signal } = params;
+
+        const safeCall = async <T>(promise: Promise<T>, fallback: T): Promise<T> => {
+            try {
+                return await promise;
+            } catch (error) {
+                if (isAbortError(error)) {
+                    throw error;
+                }
+                console.warn('[backendGateway] local snapshot call failed, using fallback value.', error);
+                return fallback;
+            }
+        };
+
+        const [
+            projects,
+            users,
+            equipment,
+            assignments,
+            logs,
+            insights,
+        ] = await Promise.all([
+            safeCall(api.getProjectsByManager(userId, { signal }) as Promise<Project[]>, [] as Project[]),
+            safeCall(api.getUsersByCompany(companyId, { signal }) as Promise<User[]>, [] as User[]),
+            safeCall(api.getEquipmentByCompany(companyId, { signal }) as Promise<Equipment[]>, [] as Equipment[]),
+            safeCall(api.getResourceAssignments(companyId, { signal }) as Promise<ResourceAssignment[]>, [] as ResourceAssignment[]),
+            safeCall(api.getAuditLogsByCompany(companyId, { signal }) as Promise<AuditLog[]>, [] as AuditLog[]),
+            safeCall(
+                api
+                    .getOperationalInsights(companyId, { signal })
+                    .then(result => result as OperationalInsights | null),
+                null as OperationalInsights | null,
+            ),
+        ]);
+
+        const activeProjectIds = new Set(
+            projects
+                .filter(project => normaliseStatus(project.status) === 'ACTIVE')
+                .map(project => String(project.id)),
+        );
+        const projectIds = new Set(projects.map(project => String(project.id)));
+
+        const tasks = activeProjectIds.size
+            ? await safeCall(
+                  api.getTodosByProjectIds(Array.from(activeProjectIds), { signal }) as Promise<Todo[]>,
+                  [] as Todo[],
+              )
+            : ([] as Todo[]);
+
+        const [incidents, expenses] = await Promise.all([
+            safeCall(api.getSafetyIncidentsByCompany(companyId, { signal }) as Promise<SafetyIncident[]>, [] as SafetyIncident[]),
+            safeCall(api.getExpensesByCompany(companyId, { signal }) as Promise<Expense[]>, [] as Expense[]),
+        ]);
+
+        const equipmentAssignments = assignments.filter(assignment => {
+            if (assignment.resourceType !== 'equipment') {
+                return false;
+            }
+            const projectId = asStringId(assignment.projectId);
+            return projectId != null && activeProjectIds.has(projectId);
+        });
+
+        const assignedEquipmentIds = new Set(equipmentAssignments.map(assignment => String(assignment.resourceId)));
+        const filteredEquipment = assignedEquipmentIds.size > 0
+            ? equipment.filter(item => assignedEquipmentIds.has(String(item.id)))
+            : equipment;
+
+        const filteredTeam = users.filter(user => user.role !== Role.PRINCIPAL_ADMIN);
+
+        const activityLog = logs
+            .filter(log => typeof log.action === 'string' && log.action.toLowerCase().includes('task'))
+            .sort((a, b) => new Date(b.timestamp ?? '').getTime() - new Date(a.timestamp ?? '').getTime())
+            .slice(0, 50);
+
+        const scopedIncidents = incidents.filter(incident => {
+            if (incident.companyId) {
+                return String(incident.companyId) === companyId;
+            }
+            if (incident.projectId) {
+                return projectIds.has(String(incident.projectId));
+            }
+            return true;
+        });
+
+        const snapshot: DashboardSnapshot = {
+            projects,
+            team: filteredTeam,
+            equipment: filteredEquipment,
+            tasks,
+            activityLog,
+            operationalInsights: insights ?? null,
+            incidents: scopedIncidents,
+            expenses,
+            portfolioSummary: computeProjectPortfolioSummary(projects),
+            metadata: {
+                source: 'mock',
+                generatedAt: new Date().toISOString(),
+                usedFallback: true,
+                projectCount: projects.length,
+            },
+        };
+
+        return snapshot;
+    }
+
+    private async fetchFromBackend<T>(path: string, init: RequestInit & { signal?: AbortSignal } = {}): Promise<T> {
+        if (!this.connectionInfo.baseUrl) {
+            throw new ApiError('No backend configured', 503);
+        }
+
+        const url = `${this.connectionInfo.baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+        const { signal, ...rest } = init;
+        const controller = new AbortController();
+        const abortListener = () => controller.abort();
+        const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
+        if (signal) {
+            if (signal.aborted) {
+                clearTimeout(timeoutId);
+                throw new DOMException('Aborted', 'AbortError');
+            }
+            signal.addEventListener('abort', abortListener);
+        }
+
+        try {
+            const response = await fetch(url, {
+                ...rest,
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    ...(rest.headers ?? {}),
+                },
+                signal: controller.signal,
+            });
+
+            if (!response.ok) {
+                let errorBody: any = null;
+                try {
+                    errorBody = await response.json();
+                } catch {
+                    // Ignore JSON parsing issues
+                }
+                throw new ApiError(
+                    errorBody?.message || `HTTP ${response.status}`,
+                    response.status,
+                    errorBody?.code,
+                    errorBody,
+                );
+            }
+
+            if (response.status === 204) {
+                return null as T;
+            }
+
+            const text = await response.text();
+            if (!text) {
+                return null as T;
+            }
+
+            try {
+                return JSON.parse(text) as T;
+            } catch (error) {
+                console.warn('[backendGateway] failed to parse backend response as JSON, returning raw text', error);
+                return text as unknown as T;
+            }
+        } catch (error) {
+            if (isAbortError(error)) {
+                throw error;
+            }
+            if (error instanceof ApiError) {
+                throw error;
+            }
+            throw new ApiError(error instanceof Error ? error.message : 'Failed to reach backend service', 503);
+        } finally {
+            clearTimeout(timeoutId);
+            if (signal) {
+                signal.removeEventListener('abort', abortListener);
+            }
+        }
+    }
+
+    private async sendInteractionToBackend(interaction: QueuedInteraction): Promise<void> {
+        const { attempts, lastError, ...payload } = interaction;
+        await this.fetchFromBackend('/app/interactions', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+    }
+
+    private async syncQueuedInteractions(): Promise<void> {
+        if (this.syncingQueue) {
+            return;
+        }
+        if (!this.queue.length) {
+            return;
+        }
+        if (this.connectionInfo.mode !== 'backend' || !this.connectionInfo.baseUrl || !this.state.online) {
+            return;
+        }
+
+        this.syncingQueue = true;
+
+        try {
+            while (this.queue.length > 0) {
+                const current = this.queue[0];
+                try {
+                    await this.sendInteractionToBackend(current);
+                    this.queue.shift();
+                    this.persistQueue();
+                    this.setState({ pendingMutations: this.queue.length, lastSync: current.createdAt ?? new Date().toISOString() });
+                } catch (error) {
+                    if (isAbortError(error)) {
+                        throw error;
+                    }
+
+                    current.attempts += 1;
+                    current.lastError = error instanceof Error ? error.message : String(error);
+                    this.persistQueue();
+
+                    if (current.attempts >= 3) {
+                        console.error('[backendGateway] dropping interaction after repeated failures', current);
+                        this.queue.shift();
+                        this.persistQueue();
+                        this.setState({ pendingMutations: this.queue.length });
+                        continue;
+                    }
+
+                    console.warn('[backendGateway] interaction sync failed, will retry later', error);
+                    break;
+                }
+            }
+        } finally {
+            this.syncingQueue = false;
+        }
+    }
+
+    private handleOnline = () => {
+        this.setState({ online: true });
+        void this.syncQueuedInteractions();
+    };
+
+    private handleOffline = () => {
+        this.setState({ online: false });
+    };
+
+    private refreshConnectionInfo() {
+        this.connectionInfo = getAuthConnectionInfo();
+        this.setState({ mode: this.connectionInfo.mode, baseUrl: this.connectionInfo.baseUrl });
+
+        if (this.connectionInfo.mode === 'backend' && this.state.online) {
+            void this.syncQueuedInteractions();
+        }
+    }
+
+    private setState(patch: Partial<BackendConnectionState>) {
+        this.state = { ...this.state, ...patch };
+        this.emitState();
+    }
+
+    private emitState() {
+        const snapshot = { ...this.state };
+        this.listeners.forEach(listener => {
+            try {
+                listener(snapshot);
+            } catch (error) {
+                console.error('[backendGateway] state listener threw an error', error);
+            }
+        });
+    }
+
+    private loadQueue(): QueuedInteraction[] {
+        try {
+            const stored = this.storage.getItem(QUEUE_STORAGE_KEY);
+            if (!stored) {
+                return [];
+            }
+            const parsed = JSON.parse(stored);
+            if (!Array.isArray(parsed)) {
+                return [];
+            }
+            return parsed
+                .map((entry: Partial<QueuedInteraction>) => ({
+                    id: entry.id ?? this.generateId(),
+                    type: entry.type ?? 'unknown',
+                    userId: entry.userId,
+                    companyId: entry.companyId,
+                    context: entry.context ?? {},
+                    createdAt: entry.createdAt ?? new Date().toISOString(),
+                    metadata: entry.metadata ?? {},
+                    attempts: entry.attempts ?? 0,
+                    lastError: entry.lastError,
+                }))
+                .slice(-100);
+        } catch (error) {
+            console.warn('[backendGateway] failed to restore interaction queue from storage', error);
+            return [];
+        }
+    }
+
+    private persistQueue() {
+        try {
+            this.storage.setItem(QUEUE_STORAGE_KEY, JSON.stringify(this.queue));
+        } catch (error) {
+            console.warn('[backendGateway] failed to persist interaction queue', error);
+        }
+    }
+
+    private enforceQueueLimit(limit = 100) {
+        if (this.queue.length <= limit) {
+            return;
+        }
+        this.queue.splice(0, this.queue.length - limit);
+        this.persistQueue();
+    }
+
+    private generateId(): string {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+            return crypto.randomUUID();
+        }
+        return `queue-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+}
+
+export const backendGateway = BackendGateway.getInstance();

--- a/types.ts
+++ b/types.ts
@@ -787,6 +787,45 @@ export interface OperationalInsights {
     alerts: OperationalAlert[];
 }
 
+export interface DashboardSnapshotMetadata {
+    source: 'mock' | 'backend';
+    generatedAt: string;
+    usedFallback: boolean;
+    projectCount?: number;
+    [key: string]: unknown;
+}
+
+export interface DashboardSnapshot {
+    projects: Project[];
+    team: User[];
+    equipment: Equipment[];
+    tasks: Todo[];
+    activityLog: AuditLog[];
+    operationalInsights: OperationalInsights | null;
+    incidents: SafetyIncident[];
+    expenses: Expense[];
+    portfolioSummary: ProjectPortfolioSummary | null;
+    metadata: DashboardSnapshotMetadata;
+}
+
+export interface BackendInteractionEvent {
+    id?: string;
+    type: string;
+    userId?: string;
+    companyId?: string;
+    context?: Record<string, unknown>;
+    createdAt?: string;
+    metadata?: Record<string, unknown>;
+}
+
+export interface BackendConnectionState {
+    mode: 'mock' | 'backend';
+    baseUrl: string | null;
+    online: boolean;
+    pendingMutations: number;
+    lastSync: string | null;
+}
+
 export interface ProjectTemplate {
     id: string;
     name: string;


### PR DESCRIPTION
## Summary
- introduce a backend gateway service that orchestrates dashboard snapshots, caching, offline queueing, and remote fallbacks
- extend shared types to describe dashboard snapshots and backend interaction metadata
- refactor the dashboard to use the new gateway and record backend interactions
- add coverage for the gateway and install testing/build dependencies needed for the suite

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d12dbc8fe08327a2850a9c16b4b112