### PR TITLE
Potential fix for code scanning alert no. 13: Client-side URL redirect

### DIFF
--- a/services/notificationService 3.ts
+++ b/services/notificationService 3.ts
@@ -181,16 +181,16 @@ export class NotificationService {
    */
   private isSafeUrl(url: string): boolean {
     try {
-      // Relative path (not protocol or host)
-      if (url.startsWith('/')) return true;
-      // Absolute: Check same-origin
-      const dest = new URL(url, window.location.href);
+      // Block protocol-relative URLs (e.g., //evil.com)
+      if (/^\/\//.test(url)) return false;
+      // Resolve the URL against the current origin
+      const dest = new URL(url, window.location.origin);
+      // Only allow same-origin URLs
       return dest.origin === window.location.origin;
     } catch (e) {
       // Invalid URLs are considered unsafe
       return false;
     }
-  }
 
 
   // Push notification subscription

--- a/services/notificationService 3.ts
+++ b/services/notificationService 3.ts
@@ -160,8 +160,10 @@ export class NotificationService {
         notification.close();
 
         // Handle notification click based on data
-        if (options.data?.url) {
+        if (options.data?.url && this.isSafeUrl(options.data.url)) {
           window.location.href = options.data.url;
+        } else if (options.data?.url) {
+          console.warn('Blocked unsafe notification redirect:', options.data.url);
         }
       };
 
@@ -173,6 +175,23 @@ export class NotificationService {
       console.error('Failed to show browser notification:', error);
     }
   }
+  /**
+   * Helper to validate URLs for safe client-side redirects
+   * Allows only relative paths or same-origin absolute URLs
+   */
+  private isSafeUrl(url: string): boolean {
+    try {
+      // Relative path (not protocol or host)
+      if (url.startsWith('/')) return true;
+      // Absolute: Check same-origin
+      const dest = new URL(url, window.location.origin);
+      return dest.origin === window.location.origin;
+    } catch (e) {
+      // Invalid URLs are considered unsafe
+      return false;
+    }
+  }
+
 
   // Push notification subscription
   async subscribeToPush(): Promise<NotificationSubscription | null> {

--- a/services/notificationService 3.ts
+++ b/services/notificationService 3.ts
@@ -184,7 +184,7 @@ export class NotificationService {
       // Relative path (not protocol or host)
       if (url.startsWith('/')) return true;
       // Absolute: Check same-origin
-      const dest = new URL(url, window.location.origin);
+      const dest = new URL(url, window.location.href);
       return dest.origin === window.location.origin;
     } catch (e) {
       // Invalid URLs are considered unsafe


### PR DESCRIPTION
Potential fix for [https://github.com/adrianstanca1/final/security/code-scanning/13](https://github.com/adrianstanca1/final/security/code-scanning/13)

To remedy this vulnerability, we should validate the destination URL before using it for a redirect. The safest approach is to restrict redirects only to a small set of trusted destinations or only to local (same-origin) paths. For this notification service, the best practice is to ensure the URL is either a relative URL (starting with `/`) or, if an absolute URL, it matches the document origin. This avoids sending users to attacker-controlled domains. We'll change the click handler to validate `options.data.url` before setting `window.location.href`. If the URL does not match our criteria, the redirect will not occur (optionally, we can log or notify the user). All changes are contained in the browser notification display logic in `showBrowserNotification`, lines 158–166.

We'll add an `isSafeUrl()` helper function within the same class, to check if a URL is same-origin or a relative path. No additional dependencies are needed, as this can be implemented using the standard `URL` constructor.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
